### PR TITLE
Modify context for user tracks

### DIFF
--- a/app/actions/albums/GetAlbums/actions.js
+++ b/app/actions/albums/GetAlbums/actions.js
@@ -47,17 +47,20 @@ export function getAlbumsRequest(
  * @author Aldo Gonzalez <aldo@tunerinc.com>
  * 
  * @param   {string[]} albums          The Spotify ids of the albums in the current user's library
+ * @param   {number}   total           The total amount of albums in the current user's library
  * @param   {boolean}  [replace=false] Whether the albums need to be replaced
  *
  * @returns {object}                   Redux action with the type of GET_ALBUMS_SUCCESS and the albums to add
  */
 export function getAlbumsSuccess(
   albums: Array<string>,
+  total: number,
   replace?: boolean = false,
 ): Action {
   return {
     type: types.GET_ALBUMS_SUCCESS,
     albums,
+    total,
     replace,
   };
 }

--- a/app/actions/albums/GetAlbums/actions.test.js
+++ b/app/actions/albums/GetAlbums/actions.test.js
@@ -22,15 +22,17 @@ describe('get albums synchronous action creators', () => {
 
   it('creates get albums success action', () => {
     const albums: Array<string> = ['foo', 'bar'];
+    const total: number = 5;
     const replace: boolean = true;
     const expectedAction: Action = {
       type: types.GET_ALBUMS_SUCCESS,
       albums,
+      total,
       replace,
     };
 
-    expect(actions.getAlbumsSuccess(albums)).toStrictEqual({...expectedAction, replace: false});
-    expect(actions.getAlbumsSuccess(albums, replace)).toStrictEqual(expectedAction);
+    expect(actions.getAlbumsSuccess(albums, total)).toStrictEqual({...expectedAction, replace: false});
+    expect(actions.getAlbumsSuccess(albums, total, replace)).toStrictEqual(expectedAction);
   });
 
   it('creates get albums failure action', () => {

--- a/app/actions/albums/GetAlbums/index.js
+++ b/app/actions/albums/GetAlbums/index.js
@@ -76,7 +76,7 @@ export function getAlbums(
     dispatch(actions.getAlbumsRequest(refreshing));
 
     try {
-      const {items} = await getMySavedAlbums({limit, offset, market});
+      const {items, total} = await getMySavedAlbums({limit, offset, market});
       const albumsFromSpotify = items.map(item => item.album);
 
       let artists: Artists = {};
@@ -144,7 +144,7 @@ export function getAlbums(
       dispatch(addArtists(artists));
       dispatch(addAlbums(albums));
       dispatch(addTracks(tracks));
-      dispatch(actions.getAlbumsSuccess(albumsFromSpotify.map(a => a.id)));
+      dispatch(actions.getAlbumsSuccess(albumsFromSpotify.map(a => a.id), total));
     } catch (err) {
       dispatch(actions.getAlbumsFailure(err));
     }

--- a/app/actions/albums/GetAlbums/reducers.js
+++ b/app/actions/albums/GetAlbums/reducers.js
@@ -57,6 +57,7 @@ export function request(
  * @param   {object}   action         The Redux action
  * @param   {string}   action.type    The type of Redux action
  * @param   {string[]} action.albums  The Spotify ids of the albums saved in the current user's library
+ * @param   {number}   action.total   The total number of albums in the current user's library
  * @param   {boolean}  action.replace Whether or not the albums need to be replaced
  * 
  * @returns {object}                  The state with the current user's saved albums added
@@ -66,7 +67,7 @@ export function success(
   action: Action,
 ): State {
   const {refreshingAlbums, userAlbums: oldAlbums} = state;
-  const {albums, replace} = action;
+  const {albums, total, replace} = action;
   const updates = (
     typeof refreshingAlbums === 'boolean'
     && typeof replace === 'boolean'
@@ -75,6 +76,7 @@ export function success(
   )
     ? {
       lastUpdated,
+      totalUserAlbums: total,
       userAlbums: refreshingAlbums || replace
         ? [...albums]
         : [...oldAlbums, ...albums],

--- a/app/actions/albums/GetAlbums/reducers.test.js
+++ b/app/actions/albums/GetAlbums/reducers.test.js
@@ -41,39 +41,40 @@ describe('get albums reducer', () => {
 
   it('should handle GET_ALBUMS_SUCCESS', () => {
     const userAlbums: Array<string> = ['bar', 'xyz'];
+    const totalUserAlbums: number = 5;
     const replace: boolean = true;
 
     expect(
       reducer(
         {...initialState, fetchingAlbums: true},
-        actions.getAlbumsSuccess(userAlbums),
+        actions.getAlbumsSuccess(userAlbums, totalUserAlbums),
       ),
     )
-      .toStrictEqual({...initialState, userAlbums});
+      .toStrictEqual({...initialState, totalUserAlbums, userAlbums});
 
     expect(
       reducer(
         {...initialState, userAlbums: ['xyz'], fetchingAlbums: true},
-        actions.getAlbumsSuccess(userAlbums),
+        actions.getAlbumsSuccess(userAlbums, totalUserAlbums),
       ),
     )
-      .toStrictEqual({...initialState, userAlbums: ['xyz', ...userAlbums]});
+      .toStrictEqual({...initialState, totalUserAlbums, userAlbums: ['xyz', ...userAlbums]});
     
     expect(
       reducer(
         {...initialState, userAlbums: ['xyz'], fetchingAlbums: true},
-        actions.getAlbumsSuccess(userAlbums, replace),
+        actions.getAlbumsSuccess(userAlbums, totalUserAlbums, replace),
       ),
     )
-      .toStrictEqual({...initialState, userAlbums});
+      .toStrictEqual({...initialState, totalUserAlbums, userAlbums});
 
     expect(
       reducer(
         {...initialState, userAlbums: ['xyz'], refreshingAlbums: true, fetchingAlbums: true},
-        actions.getAlbumsSuccess(userAlbums),
+        actions.getAlbumsSuccess(userAlbums, totalUserAlbums),
       ),
     )
-      .toStrictEqual({...initialState, userAlbums});
+      .toStrictEqual({...initialState, totalUserAlbums, userAlbums});
   });
 
   it('should handle GET_ALBUMS_FAILURE', () => {

--- a/app/actions/artists/GetArtists/index.js
+++ b/app/actions/artists/GetArtists/index.js
@@ -151,8 +151,14 @@ export function getArtists(
       dispatch(addAlbums(music.albums));
       dispatch(addTracks(music.tracks));
       dispatch(actions.getArtistsSuccess(sortedArtists));
-      dispatch(getAlbumsSuccess(albumsFromSpotify.map(a => a.album.id), true));
-      dispatch(getTracksSuccess(tracksFromSpotify.map(t => t.track.id), true));
+
+      dispatch(
+        getAlbumsSuccess(albumsFromSpotify.map(a => a.album.id), albumsFromSpotify.length, true),
+      );
+
+      dispatch(
+        getTracksSuccess(tracksFromSpotify.map(t => t.track.id), tracksFromSpotify.length, true),
+      );
     } catch (err) {
       dispatch(actions.getArtistsFailure(err));
     }

--- a/app/actions/tracks/GetTracks/actions.js
+++ b/app/actions/tracks/GetTracks/actions.js
@@ -42,17 +42,20 @@ export function getTracksRequest(
  * @author Aldo Gonzalez <aldo@tunerinc.com>
  * 
  * @param   {string[]} tracks          The Spotify track ids from the current user's library
+ * @param   {number}   total           The total number of tracks in the current user's library
  * @param   {boolean}  [replace=false] Whether or not the tracks need to be replaced
  *
- * @returns {object}                   Redux action with the type of GET_TRACKS_SUCCESS and the tracks from the library
+ * @returns {object}                   Redux action with the type of GET_TRACKS_SUCCESS, the tracks from the library, the total number of tracks, and whether to replace the cached tracks
  */
 export function getTracksSuccess(
   tracks: Array<string>,
+  total: number,
   replace?: boolean = false,
 ): Action {
   return {
     type: types.GET_TRACKS_SUCCESS,
     tracks,
+    total,
     replace,
   };
 }

--- a/app/actions/tracks/GetTracks/actions.test.js
+++ b/app/actions/tracks/GetTracks/actions.test.js
@@ -22,15 +22,17 @@ describe('get tracks synchronous action creators', () => {
 
   it('creates get tracks success action', () => {
     const tracks: Array<string> = ['bar', 'xyz'];
+    const total: number = 2;
     const replace: boolean = true;
     const expectedAction: Action = {
       type: types.GET_TRACKS_SUCCESS,
       tracks,
+      total,
       replace,
     };
 
-    expect(actions.getTracksSuccess(tracks)).toStrictEqual({...expectedAction, replace: false});
-    expect(actions.getTracksSuccess(tracks, replace)).toStrictEqual(expectedAction);
+    expect(actions.getTracksSuccess(tracks, total)).toStrictEqual({...expectedAction, replace: false});
+    expect(actions.getTracksSuccess(tracks, total, replace)).toStrictEqual(expectedAction);
   });
 
   it('creates get tracks failure action', () => {

--- a/app/actions/tracks/GetTracks/index.js
+++ b/app/actions/tracks/GetTracks/index.js
@@ -50,14 +50,14 @@ export function getTracks(
     dispatch(actions.getTracksRequest(refreshing));
 
     try {
-      const {items} = await getMySavedTracks(options);
+      const {items, total} = await getMySavedTracks(options);
       const music = addMusicItems(items);
       const tracks: Array<string> = items.map(item => item.track.id)
 
       dispatch(addArtists(music.artists));
       dispatch(addAlbums(music.albums));
       dispatch(addTracks(music.tracks));
-      dispatch(actions.getTracksSuccess(tracks));
+      dispatch(actions.getTracksSuccess(tracks, total));
     } catch (err) {
       dispatch(actions.getTracksFailure(err));
     }

--- a/app/actions/tracks/GetTracks/reducers.js
+++ b/app/actions/tracks/GetTracks/reducers.js
@@ -57,6 +57,7 @@ export function request(
  * @param   {object}   action         The Redux action
  * @param   {string}   action.type    The type of Redux action
  * @param   {string[]} action.tracks  The Spotify ids of the current user's library tracks
+ * @param   {number}   action.total   The total number of tracks in the current user's library
  * @param   {boolean}  action.replace Whether or not all the tracks need to be replaced
  * 
  * @returns {object}                  The state with the library track ids added
@@ -66,7 +67,7 @@ export function success(
   action: Action,
 ): State {
   const {refreshingTracks, userTracks} = state;
-  const {tracks, replace} = action;
+  const {tracks, total, replace} = action;
   const updates = (
     typeof refreshingTracks === 'boolean'
     && typeof replace === 'boolean'
@@ -75,6 +76,7 @@ export function success(
   )
     ? {
       lastUpdated,
+      totalUserTracks: total,
       refreshingTracks: false,
       fetchingTracks: false,
       error: null,

--- a/app/actions/tracks/GetTracks/reducers.test.js
+++ b/app/actions/tracks/GetTracks/reducers.test.js
@@ -41,39 +41,40 @@ describe('get tracks reducer', () => {
 
   it('should handle GET_TRACKS_SUCCESS', () => {
     const userTracks: Array<string> = ['bar', 'xyz'];
+    const totalUserTracks: number = 5;
     const replace: boolean = true;
 
     expect(
       reducer(
         {...initialState, fetchingTracks: true},
-        actions.getTracksSuccess(userTracks),
+        actions.getTracksSuccess(userTracks, totalUserTracks),
       ),
     )
-      .toStrictEqual({...initialState, userTracks});
+      .toStrictEqual({...initialState, totalUserTracks, userTracks});
 
     expect(
       reducer(
         {...initialState, fetchingTracks: true, userTracks: ['foo']},
-        actions.getTracksSuccess(userTracks),
+        actions.getTracksSuccess(userTracks, totalUserTracks),
       ),
     )
-      .toStrictEqual({...initialState, userTracks: ['foo', ...userTracks]});
+      .toStrictEqual({...initialState, totalUserTracks, userTracks: ['foo', ...userTracks]});
 
     expect(
       reducer(
         {...initialState, fetchingTracks: true, userTracks: ['foo']},
-        actions.getTracksSuccess(userTracks, replace),
+        actions.getTracksSuccess(userTracks, totalUserTracks, replace),
       ),
     )
-      .toStrictEqual({...initialState, userTracks});
+      .toStrictEqual({...initialState, totalUserTracks, userTracks});
 
     expect(
       reducer(
         {...initialState, refreshingTracks: true, fetchingTracks: true, userTracks: ['foo']},
-        actions.getTracksSuccess(userTracks),
+        actions.getTracksSuccess(userTracks, totalUserTracks),
       ),
     )
-      .toStrictEqual({...initialState, userTracks});
+      .toStrictEqual({...initialState, totalUserTracks, userTracks});
   });
 
   it('should handle GET_TRACKS_FAILURE', () => {

--- a/app/containers/LibraryTracksView/index.js
+++ b/app/containers/LibraryTracksView/index.js
@@ -163,7 +163,7 @@ class LibraryTracksView extends React.Component {
       albums: {albumsByID},
       sessions: {currentSessionID, sessionsByID},
       settings: {preference: {session: mode}},
-      tracks: {tracksByID},
+      tracks: {userTracks, totalUserTracks, tracksByID},
       users: {currentUserID, usersByID},
     } = this.props;
     const currentSession = sessionsByID[currentSessionID];
@@ -202,8 +202,9 @@ class LibraryTracksView extends React.Component {
           id: currentUserID,
           name: displayName,
           type: 'user-tracks',
-          total: 1,
+          total: totalUserTracks,
           position: trackIndex,
+          tracks: userTracks.slice(trackIndex + 1),
         },
         mode,
       );

--- a/app/reducers/albums.js
+++ b/app/reducers/albums.js
@@ -65,6 +65,7 @@ type Action = {
   +trackIDs?: Array<string>,
   +albumCount?: number,
   +replace?: boolean,
+  +total?: number,
 };
 
 type State = {
@@ -139,6 +140,7 @@ const singleState: Album = {
  * 
  * @property {string}   lastUpdated             The date/time the albums were last updated
  * @property {string[]} userAlbums              The Spotify album ids saved in the current user's library
+ * @property {number}   totalUserAlbums=0       The total number of albums in the current user's library
  * @property {object}   albumsByID              The album objects using the Spotify id as the key
  * @property {number}   totalAlbums             The total amount of albums
  * @property {string}   selectedAlbum=null      The selected album to view
@@ -155,6 +157,7 @@ const singleState: Album = {
 export const initialState: State = {
   lastUpdated,
   userAlbums: [],
+  totalUserAlbums: 0,
   albumsByID: {},
   totalAlbums: 0,
   selectedAlbum: null,

--- a/app/reducers/tracks.js
+++ b/app/reducers/tracks.js
@@ -60,6 +60,7 @@ type Action = {
   +trackID?: string,
   +trackCount?: number,
   +replace?: boolean,
+  +total?: number,
 };
 
 type State = {
@@ -127,6 +128,7 @@ const singleState: Track = {
  * 
  * @property {string}   lastUpdated                 The date/time the tracks were last updated
  * @property {string[]} userTracks                  The Spotify track ids saved in the current user's library
+ * @property {number}   totalUserTracks=0           The total amount of tracks in the current user's library
  * @property {object}   tracksByID                  The track objects using the Spotify ids as the key
  * @property {number}   totalTracks=0               The total amount of tracks
  * @property {string}   selectedTrack=null          The selected track to view
@@ -144,6 +146,7 @@ const singleState: Track = {
 export const initialState: State = {
   lastUpdated,
   userTracks: [],
+  totalUserTracks: 0,
   tracksByID: {},
   totalTracks: 0,
   selectedTrack: null,


### PR DESCRIPTION
### Description

The main purpose of this pull request is to add the ids of the tracks that will be inside of the context queue coming from the current user's Spotify library. To supplement this functionality, the totals for albums and tracks in the current user's library will be added to the state objects for both of those respectively.

#### Test Plan

```
npm test app/actions/albums/GetAlbums/

npm test app/actions/tracks/GetTracks/

npm test app/actions/sessions/CreateSession/
```

### Motivation and Context

When transferring over the codebase from the old repo, I included some limited functionality when creating a session and playing a track. These updates are filling in some of the holes left from the transfer that I had left. As far as the totals for items in the user's library, this makes the process of paginating the current user's library much easier, allowing for performance improvements not only with calculating the tracks in the context queue when creating a session, but also when doing those respective tasks on their own.

### How Has This Been Tested?

Thus far, all of the synchronous action creators and the reducer case functions handling those actions have all their unit tests passing. I also tested manually by checking the context being created with these changes implemented to ensure everything was performing as expected.

### Screenshots (if appropriate)

N/A

### Types of Changes

- [x] Documentation
- ~~Bug fix~~
- ~~New feature~~
- ~~Breaking change~~

#### Bug Fixes

N/A

#### Breaking Changes

N/A

### Checklist

- [x] My code follows the code style of this project
- [x] My change requires tests to be written
- [x] I have written the tests necessary for my code
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly