### PR TITLE
Implement update player

### DIFF
--- a/app/actions/player/UpdatePlayer/actions.test.js
+++ b/app/actions/player/UpdatePlayer/actions.test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+/**
+ * @format
+ * @flow
+ */
+
+import * as actions from '../UpdatePlayer';
+import * as types from '../types';
+import {
+  type Action,
+  type Updates,
+} from '../../../reducers/player';
+
+describe('update player synchronous action creator', () => {
+  it('creates action to update the player', () => {
+    const updates: Updates = {
+      attemptingToPlay: false,
+      prevTrackID: 'foo',
+      prevQueueID: 'foo',
+      currentTrackID: 'foo',
+      currentQueueID: 'foo',
+      nextTrackID: 'foo',
+      nextQueueID: 'foo',
+    };
+
+    const expectedAction: Action = {
+      type: types.UPDATE_PLAYER,
+      updates,
+    };
+
+    expect(actions.updatePlayer(updates)).toStrictEqual(expectedAction);
+  });
+});

--- a/app/actions/player/UpdatePlayer/index.js
+++ b/app/actions/player/UpdatePlayer/index.js
@@ -1,0 +1,43 @@
+'use strict';
+
+/**
+ * @format
+ * @flow
+ */
+
+/**
+ * @module UpdatePlayer
+ */
+
+import * as types from '../types';
+import {
+  type Action,
+  type Updates,
+} from '../../../reducers/player';
+
+/**
+ * Update the player with any new information
+ * 
+ * @function updatePlayer
+ * 
+ * @author Aldo Gonzalez <aldo@tunerinc.com>
+ * 
+ * @param   {object}  updates                    The updates to make to the player
+ * @param   {boolean} [updates.attemptingToPlay] The new status of whether the current user is attempting to play a track
+ * @param   {string}  [updates.prevTrackID]      The Spotify id of the new previous track
+ * @param   {string}  [updates.prevQueueID]      The queue id of the new previous track
+ * @param   {string}  [updates.currentTrackID]   The Spotify id of the new current track
+ * @param   {string}  [updates.currentQueueID]   The queue id of the new current track
+ * @param   {string}  [updates.nextTrackID]      The Spotify id of the new next track
+ * @param   {string}  [updates.nextQueueID]      The queue id of the new next track
+ * 
+ * @returns {object}                             Redux action with the type of UPDATE_PLAYER and the updates to make to the player
+ */
+export function updatePlayer(
+  updates: Updates,
+): Action {
+  return {
+    type: types.UPDATE_PLAYER,
+    updates,
+  };
+}

--- a/app/actions/player/UpdatePlayer/reducers.js
+++ b/app/actions/player/UpdatePlayer/reducers.js
@@ -1,0 +1,45 @@
+'use strict';
+
+/**
+ * @format
+ * @flow
+ */
+
+/**
+ * @module UpdatePlayerReducers
+ */
+
+import updateObject from '../../../utils/updateObject';
+import {
+  type Action,
+  type State,
+} from '../../../reducers/player';
+
+/**
+ * Updates the player state with new information
+ * 
+ * @function updatePlayer
+ * 
+ * @author Aldo Gonzalez <aldo@tunerinc.com>
+ * 
+ * @param {object}   state 
+ * @param {object}   action 
+ * @param {string}   action.type
+ * @param {object}   action.updates
+ * @param {boolean}  [action.updates.attemptingToPlay] The new status for whether the current user is attempting to play a track
+ * @param {string}   [action.updates.prevTrackID]       The Spotify id for the new previous track
+ * @param {string}   [action.updates.prevQueueID]       The queue id for the new previous track
+ * @param {string}   [action.updates.currentTrackID]    The Spotify id for the new current track
+ * @param {string}   [action.updates.currentQueueID]    The queue id for the new current track
+ * @param {string}   [action.updates.nextTrackID]       The Spotify id for the new next track
+ * @param {string}   [action.updates.nextQueueID]       The queue id for the new next track
+ * 
+ * @returns {object}                                    The state with new updates added
+ */
+export function updatePlayer(
+  state: State,
+  action: Action,
+): State {
+  const {updates} = action;
+  return updateObject(state, updates);
+}

--- a/app/actions/player/UpdatePlayer/reducers.test.js
+++ b/app/actions/player/UpdatePlayer/reducers.test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+/**
+ * @format
+ * @flow
+ */
+
+import reducer, {
+  initialState,
+  type Updates,
+} from '../../../reducers/player';
+import * as actions from '../UpdatePlayer';
+
+describe('update player reducer', () => {
+  it('should return intial state', () => {
+    expect(reducer(undefined, {})).toStrictEqual(initialState);
+  });
+
+  it('should handle UPDATE_PLAYER', () => {
+    const updates: Updates = {
+      attemptingToPlay: true,
+      prevTrackID: 'foo',
+      prevQueueID: 'foo',
+      currentTrackID: 'foo',
+      currentQueueID: 'foo',
+      nextTrackID: 'foo',
+      nextQueueID: 'foo',
+    };
+
+    expect(reducer(initialState, actions.updatePlayer(updates)))
+      .toStrictEqual(
+        {
+          ...initialState,
+          ...updates,
+        },
+      );
+  });
+});

--- a/app/actions/queue/QueueTrack/actions.test.js
+++ b/app/actions/queue/QueueTrack/actions.test.js
@@ -11,18 +11,12 @@ import {type Action} from '../../../reducers/queue';
 
 describe('queue track synchronous action creators', () => {
   it('creates queue track request action', () => {
-    const expectedAction: Action = {
-      type: types.QUEUE_TRACK_REQUEST,
-    };
-
+    const expectedAction: Action = {type: types.QUEUE_TRACK_REQUEST};
     expect(actions.queueTrackRequest()).toStrictEqual(expectedAction);
   });
 
   it('creates queue track success action', () => {
-    const expectedAction: Action = {
-      type: types.QUEUE_TRACK_SUCCESS,
-    };
-
+    const expectedAction: Action = {type: types.QUEUE_TRACK_SUCCESS};
     expect(actions.queueTrackSuccess()).toStrictEqual(expectedAction);
   });
 


### PR DESCRIPTION
### Description

The main purpose of this pull request is to add the ability to update the player state from an action creator outside of the player state.

#### Test Plan

```
npm test app/actions/player/UpdatePlayer/
```

### Motivation and Context

The purpose for making this action creator is because there is no current way to change key elements inside of the player state from asynchronous thunks inside of the queue reducer. Not being able to update these elements in the player state prohibits `QueueTrack` from being able to update values in Firestore accurately.

### How Has This Been Tested?

Thus far, the synchronous action creator and the reducer case function have their unit tests passing.

### Screenshots (if appropriate)

N/A

### Types of Changes

- [x] Documentation
- ~~Bug fix~~
- [x] New feature
- ~~Breaking change~~

#### Bug Fixes

N/A

#### Breaking Changes

N/A

### Checklist

- [x] My code follows the code style of this project
- [x] My change requires tests to be written
- [x] I have written the tests necessary for my code
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly