### PR TITLE
Implement delete queue track

### DIFF
--- a/app/actions/queue/DeleteQueueTrack/index.js
+++ b/app/actions/queue/DeleteQueueTrack/index.js
@@ -60,6 +60,14 @@ export function deleteQueueTrack(
 
       if (nextQueueID && nextTrackID) {
         batch.update(queueRef.doc(prevQueueID), {nextQueueID, nextTrackID});
+      } else {
+        batch.update(
+          queueRef.doc(prevQueueID),
+          {
+            nextQueueID: null,
+            nextTrackID: null,
+          },
+        );
       }
 
       batch.delete(queueRef.doc(queueID));

--- a/app/actions/queue/DeleteQueueTrack/index.js
+++ b/app/actions/queue/DeleteQueueTrack/index.js
@@ -56,14 +56,15 @@ export function deleteQueueTrack(
 
     try {
       const queueTrack: FirestoreDoc = await queueRef.doc(queueID).get();
-      const {prevQueueID, nextQueueID} = queueTrack.data();
+      const {prevQueueID, prevTrackID, nextQueueID, nextTrackID} = queueTrack.data();
+
+      if (nextQueueID && nextTrackID) {
+        batch.update(queueRef.doc(prevQueueID), {nextQueueID, nextTrackID});
+      }
 
       batch.delete(queueRef.doc(queueID));
       batch.update(sessionRef, {'totals.queue': session.total - 1});
 
-      if (nextQueueID) {
-        batch.update(queueRef.doc(prevQueueID), {nextQueueID});
-      }
 
       await batch.commit();
       dispatch(actions.deleteQueueTrackSuccess(queueID));

--- a/app/components/DeleteQueueTrackButton/index.js
+++ b/app/components/DeleteQueueTrackButton/index.js
@@ -14,7 +14,7 @@ import Ionicons from 'react-native-vector-icons/Ionicons';
 import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
 
 type Props = {|
-  deleteTrack: () => any,
+  deleteTrack?: () => any,
   deleting: boolean,
   disabled: boolean,
   error: ?boolean,

--- a/app/components/TrackCard/index.js
+++ b/app/components/TrackCard/index.js
@@ -23,6 +23,7 @@ type Props = {|
   albumName?: string,
   artists?: string,
   context: Context,
+  deleteTrack?: () => void,
   deleting?: boolean,
   editing?: boolean,
   image?: string,
@@ -55,6 +56,7 @@ export default class TrackCard extends React.PureComponent<Props, State> {
     const {
       albumName,
       artists,
+      deleteTrack,
       deleting,
       editing,
       image,
@@ -155,7 +157,7 @@ export default class TrackCard extends React.PureComponent<Props, State> {
           </View>
           {(type === 'userQueue' && editing) &&
             <DeleteQueueTrackButton
-              deleteTrack={() => console.log('delete track pressed')}
+              deleteTrack={deleteTrack}
               deleting={deleting || false}
               disabled={deleting || queueError || false}
               error={queueError || null}

--- a/app/components/TrackCard/index.js
+++ b/app/components/TrackCard/index.js
@@ -159,7 +159,7 @@ export default class TrackCard extends React.PureComponent<Props, State> {
             <DeleteQueueTrackButton
               deleteTrack={deleteTrack}
               deleting={deleting || false}
-              disabled={deleting || queueError || false}
+              disabled={deleting || queueError !== null || false}
               error={queueError || null}
             />
           }

--- a/app/containers/LiveSessionView/index.js
+++ b/app/containers/LiveSessionView/index.js
@@ -95,6 +95,7 @@ class LiveSessionView extends React.Component {
     this.handleMute = this.handleMute.bind(this);
     this.skipNext = this.skipNext.bind(this);
     this.skipPrev = this.skipPrev.bind(this);
+    this.delete = this.delete.bind(this);
     this.renderTrack = this.renderTrack.bind(this);
     this.renderMessage = this.renderMessage.bind(this);
     this.toggleMenu = this.toggleMenu.bind(this);
@@ -357,6 +358,16 @@ class LiveSessionView extends React.Component {
     previousTrack(user, session);
   }
 
+  delete = queueID => () => {
+    const {
+      deleteQueueTrack,
+      queue: {totalUserQueue: total},
+      sessions: {currentSessionID: id},
+    } = this.props;
+
+    deleteQueueTrack({id, total}, queueID);
+  }
+
   renderTrack({item, index}) {
     const {editingQueue} = this.state;
     const {
@@ -377,7 +388,7 @@ class LiveSessionView extends React.Component {
         artists={artists.map(a => a.name).join(', ')}
         context={{id: ownerID, type: 'userQueue', displayName, name: 'userQueue'}}
         deleting={deleting.includes(item)}
-        deleteTrack={() => console.log('delete')}
+        deleteTrack={this.delete(item)}
         editing={editingQueue}
         image={profileImage}
         liked={liked}

--- a/app/containers/LiveSessionView/index.js
+++ b/app/containers/LiveSessionView/index.js
@@ -377,6 +377,7 @@ class LiveSessionView extends React.Component {
         artists={artists.map(a => a.name).join(', ')}
         context={{id: ownerID, type: 'userQueue', displayName, name: 'userQueue'}}
         deleting={deleting.includes(item)}
+        deleteTrack={() => console.log('delete')}
         editing={editingQueue}
         image={profileImage}
         liked={liked}


### PR DESCRIPTION
### Description

The main purpose of this pull request is to add the ability to delete tracks from the queue as the owner of a session.

#### Test Plan

```
npm test app/actions/queue/DeleteQueueTrack/
```

### Motivation and Context

The purpose for making this action creator is to allow the current user to delete tracks from the queue of their session if they wish to. Currently, there is no functionality allowing them this capability, although the get user queue real-time listener is fully capable.

### How Has This Been Tested?

Thus far, the synchronous action creators and the reducer case functions have their unit tests passing. I've tested manually as well by deleting tracks from the queue in different orders to ensure everything is being updated properly.

### Screenshots (if appropriate)

N/A

### Types of Changes

- [ ] Documentation
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

#### Bug Fixes

N/A

#### Breaking Changes

N/A

### Checklist

- [x] My code follows the code style of this project
- [x] My change requires tests to be written
- [x] I have written the tests necessary for my code
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly