### PR TITLE
Implement toggle track like

### DIFF
--- a/app/actions/queue/ToggleTrackLike/index.js
+++ b/app/actions/queue/ToggleTrackLike/index.js
@@ -52,24 +52,16 @@ export function toggleTrackLike(
     const toggleLikeTransaction: Promise<number> = firestore.runTransaction(async transaction => {
       const doc: FirestoreDoc = await transaction.get(queueTrackRef);
 
-      if (!doc.exists) {
-        throw new Error('Unable to retrieve queue track from Brassroots');
-      }
+      if (!doc.exists) throw new Error('Unable to retrieve queue track from Brassroots');
 
-      let {totalLikes} = doc.data();
-
-      if (liked) {
-        totalLikes -= 1;
-      } else {
-        totalLikes += 1;
-      }
-
-      transaction.update(
-        queueTrackRef,
-        {totalLikes},
-      );
-
-      return totalLikes;
+      transaction.update(queueTrackRef, {
+        totalLikes: liked
+          ? firestore.FieldValue.decrement(1)
+          : firestore.FieldValue.increment(1),
+        likes: liked
+          ? firestore.FieldValue.arrayRemove(userID)
+          : firestore.FieldValue.arrayUnion(userID)
+      });
     });
 
     try {

--- a/app/actions/queue/ToggleTrackLike/index.js
+++ b/app/actions/queue/ToggleTrackLike/index.js
@@ -54,9 +54,11 @@ export function toggleTrackLike(
 
       if (!doc.exists) throw new Error('Unable to retrieve queue track from Brassroots');
 
+      const {totalLikes} = doc.data();
+
       transaction.update(queueTrackRef, {
         totalLikes: liked
-          ? firestore.FieldValue.decrement(1)
+          ? totalLikes - 1
           : firestore.FieldValue.increment(1),
         likes: liked
           ? firestore.FieldValue.arrayRemove(userID)

--- a/app/components/SessionPlayer/index.js
+++ b/app/components/SessionPlayer/index.js
@@ -26,15 +26,9 @@ type Props = {|
 
 type State = {||};
 
-export default class SessionPlayer extends React.Component<Props, State> {
+export default class SessionPlayer extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
-  }
-
-  shouldComponentUpdate(nextProps: Props) {
-    const {image, paused} = this.props;
-    const {image: newImage, paused: newPaused} = nextProps;
-    return image !== newImage || paused !== newPaused;
   }
 
   render() {
@@ -48,10 +42,10 @@ export default class SessionPlayer extends React.Component<Props, State> {
       paused,
       image,
     } = this.props;
-    const prevExists = isOwner && prevTrackID;
+    const prevExists = isOwner && typeof prevTrackID === 'string';
     const prevDisabled = prevExists ? false : true;
     const prevColor = prevExists ? 'rgba(254,254,254,0.9)' : 'rgba(254,254,254,0.2)';
-    const nextExists = isOwner && nextTrackID;
+    const nextExists = isOwner && typeof nextTrackID === 'string';
     const nextDisabled = nextExists ? false : true;
     const nextColor = nextExists ? 'rgba(254,254,254,0.9)' : 'rgba(254,254,254,0.2)';
 

--- a/app/components/TrackCard/index.js
+++ b/app/components/TrackCard/index.js
@@ -25,6 +25,7 @@ type Props = {|
   context: Context,
   deleteTrack?: () => void,
   deleting?: boolean,
+  liking?: boolean,
   editing?: boolean,
   image?: string,
   liked?: boolean,
@@ -60,6 +61,7 @@ export default class TrackCard extends React.PureComponent<Props, State> {
       deleting,
       editing,
       image,
+      liking,
       liked,
       name,
       onPress,
@@ -163,9 +165,9 @@ export default class TrackCard extends React.PureComponent<Props, State> {
               error={queueError || null}
             />
           }
-          {(inQueue && !editing && toggleLike) &&
+          {(inQueue && !editing && toggleLike && typeof liking === 'boolean') &&
             <LikeButton
-              disabled={type === 'contextQueue'}
+              disabled={type === 'contextQueue' || liking}
               liked={type === 'userQueue' && typeof liked === 'boolean' && liked}
               showCount={inQueue && type !== 'contextQueue'}
               toggleLike={toggleLike}

--- a/app/containers/LiveSessionView/index.js
+++ b/app/containers/LiveSessionView/index.js
@@ -361,17 +361,17 @@ class LiveSessionView extends React.Component {
   delete = queueID => () => {
     const {
       deleteQueueTrack,
-      queue: {totalUserQueue: total},
+      queue: {userQueue},
       sessions: {currentSessionID: id},
     } = this.props;
 
-    deleteQueueTrack({id, total}, queueID);
+    deleteQueueTrack({id, total: userQueue.length}, queueID);
   }
 
   renderTrack({item, index}) {
     const {editingQueue} = this.state;
     const {
-      queue: {queueByID, deleting, error: queueError},
+      queue: {queueByID, deleting, liking, error: queueError},
       sessions: {currentSessionID, sessionsByID},
       tracks: {tracksByID},
       users: {usersByID},
@@ -391,6 +391,7 @@ class LiveSessionView extends React.Component {
         deleteTrack={this.delete(item)}
         editing={editingQueue}
         image={profileImage}
+        liking={liking.includes(item)}
         liked={liked}
         name={name}
         queueError={queueError}
@@ -622,8 +623,13 @@ class LiveSessionView extends React.Component {
   };
 
   toggleLike = (queueID, liked) => () => {
-    const {queue: {queueByID}, tracks: {tracksByID}} = this.props;
-    console.log('toggle like', tracksByID[queueByID[queueID].trackID])
+    const {
+      toggleTrackLike,
+      sessions: {currentSessionID},
+      users: {currentUserID},
+    } = this.props;
+
+    toggleTrackLike(currentSessionID, queueID, currentUserID, liked);
   }
 
   renderFooter() {

--- a/app/utils/firebaseTypes.js
+++ b/app/utils/firebaseTypes.js
@@ -58,6 +58,10 @@ type FirestoreInstance = {
   runTransaction: (any) => Promise<any>,
   FieldValue: {
     serverTimestamp: () => string | number,
+    arrayUnion: (any) => any,
+    arrayRemove: (any) => any,
+    increment: (number) => number,
+    decrement: (number) => number,
   },
 };
 


### PR DESCRIPTION
### Description

The main purpose of this pull request is to add the ability to like/unlike any of the songs that are in the queue of the session you're in.

#### Test Plan

```
npm test app/actions/queue/ToggleTrackLike/
```

### Motivation and Context

The purpose for making this action creator is to allow the current user to toggle the like status for any of the queue tracks, updating the overall total in the process to display back.

### How Has This Been Tested?

Thus far, the synchronous action creators and the reducer case functions have their unit tests passing. I've tested manually as well by toggling the like status of different songs in the queue, ensuring the feature is functioning as expected.

### Screenshots (if appropriate)

N/A

### Types of Changes

- [ ] Documentation
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

#### Bug Fixes

N/A

#### Breaking Changes

N/A

### Checklist

- [x] My code follows the code style of this project
- [x] My change requires tests to be written
- [x] I have written the tests necessary for my code
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly