### PR TITLE
Implement next track

### DIFF
--- a/app/actions/player/NextTrack/actions.js
+++ b/app/actions/player/NextTrack/actions.js
@@ -23,9 +23,7 @@ import {type Action} from '../../../reducers/player';
  * @returns {object} Redux action with the type of NEXT_TRACK_REQUEST
  */
 export function nextTrackRequest(): Action {
-  return {
-    type: types.NEXT_TRACK_REQUEST,
-  };
+  return {type: types.NEXT_TRACK_REQUEST};
 }
 
 /**

--- a/app/actions/player/NextTrack/index.js
+++ b/app/actions/player/NextTrack/index.js
@@ -15,6 +15,7 @@ import Spotify from 'rn-spotify-sdk';
 // import {addRecentTrack} from '../../tracks/AddRecentTrack';
 import updateObject from '../../../utils/updateObject';
 import * as actions from './actions';
+import {removeQueueTrack} from '../../queue/RemoveQueueTrack';
 import {type TrackArtist} from '../../../reducers/tracks';
 import {type ThunkAction} from '../../../reducers/player';
 import {
@@ -135,10 +136,11 @@ export function nextTrack(
 
       const promises = [
         batch.commit(),
-        Spotify.playURI(`spotify:track:${nextTrack.track.id}`, 0, 0),
+        Spotify.playURI(`spotify:track:${nextDoc.data().track.id}`, 0, 0),
       ];
 
       await Promise.all(promises);
+      dispatch(removeQueueTrack(nextQueueID));
       dispatch(
         actions.nextTrackSuccess(
           nextQueueID,

--- a/app/actions/player/NextTrack/index.js
+++ b/app/actions/player/NextTrack/index.js
@@ -11,8 +11,8 @@
 
 import moment from 'moment';
 import Spotify from 'rn-spotify-sdk';
-import {GeoFirestore} from 'geofirestore';
-import {addRecentTrack} from '../../tracks/AddRecentTrack';
+// import {GeoFirestore} from 'geofirestore';
+// import {addRecentTrack} from '../../tracks/AddRecentTrack';
 import updateObject from '../../../utils/updateObject';
 import * as actions from './actions';
 import {type TrackArtist} from '../../../reducers/tracks';
@@ -40,57 +40,7 @@ type Session = {
     lat: number,
     lon: number,
   },
-  current: {
-    id: string,
-    totalLikes: number,
-    userID: string,
-    prevTrackID: string,
-    track: {
-      trackID?: string,
-      timeAdded?: string | number,
-      id: string,
-      name: string,
-      trackNumber: number,
-      durationMS: number,
-      artists: Array<TrackArtist>,
-      album: {
-        id: string,
-        name: string,
-        small: string,
-        medium: string,
-        large: string,
-        artists: Array<TrackArtist>,
-      },
-    },
-  }
-};
-
-type NextTrack = {
-  id?: string,
-  totalLikes?: number,
-  userID?: string,
-  prevTrackID?: string,
-  nextQueueID?: string,
-  nextTrackID?: string,
-  position: number,
-  track: {
-    id: string,
-    durationMS: number,
-    name?: string,
-    album?: {
-      id: string,
-      name: string,
-      small: string,
-      medium: string,
-      large: string,
-    },
-    artists?: Array<
-      {
-        id: string,
-        name: string,
-      }
-    >,
-  },
+  current: string,
 };
 
 /**
@@ -102,65 +52,28 @@ type NextTrack = {
  * @author Aldo Gonzalez <aldo@tunerinc.com>
  *
  * @param    {object}   user
- * @param    {string}   user.id                              The user id of the current user
- * @param    {string}   user.displayName                     The display name of the current user
- * @param    {string}   user.profileImage                    The profile image of the current user
- * @param    {string}   session                              The session object to play the next track in
- * @param    {string}   session.id                           The id of the session to play the next track in
- * @param    {number}   session.totalQueue                   The tracks which are next to play in the session
- * @param    {number}   session.totalPlayed                  The total amount of played tracks in the session
- * @param    {number}   session.totalUsers                   The total amount of listeners in the session
- * @param    {object}   [session.coords]                     The coordinates of the session the current user is in
- * @param    {number}   session.coords.lat                   The latitude of the gps coordinates
- * @param    {number}   session.coords.lon                   The longitude of the gps coordinates
- * @param    {object}   session.current                      The track that is currently playing in the session
- * @param    {string}   session.current.id                   The queue id of the currently playing track
- * @param    {number}   session.current.totalLikes           The total amount of likes the current track has
- * @param    {string}   session.current.userID               The id of the user who queued the track
- * @param    {string}   session.current.prevTrackID          The id of the previously played track from the current track
- * @param    {object}   session.current.track                The currently playing track's Spotify information
- * @param    {string}   session.current.track.id             The Spotify track id of the current track
- * @param    {string}   session.current.track.name           The name of the track
- * @param    {number}   session.current.track.durationMS     The duration of the track in milliseconds
- * @param    {object}   session.current.track.album          The album the track is in
- * @param    {string}   session.current.track.album.id       The Spotify id of the album
- * @param    {string}   session.current.track.album.name     The name of the album
- * @param    {string}   [session.current.track.album.small]  64x64 size of the album artwork
- * @param    {string}   [session.current.track.album.medium] 300x300 size of the album artwork
- * @param    {string}   [session.current.track.album.large]  640x640 size of the album artwork
- * @param    {object[]} session.current.track.artists        The track artists
- * @param    {string}   session.current.track.artists[].id   The Spotify id of the track artist
- * @param    {string}   session.current.track.artists[].name The name of the track artist
- * @param    {object}   nextTrack                            The next track to play in the session
- * @param    {string}   [nextTrack.id]                       The queue id of the next track if from queue. if null, then from context queue
- * @param    {number}   [nextTrack.totalLikes]               The total amount of likes the current track has if from queue
- * @param    {string}   [nextTrack.userID]                   The id of the user who queued the track if from queue
- * @param    {string}   [nextTrack.prevTrackID]              The queue id of the previous track if from queue
- * @param    {string}   [nextTrack.nextQueueID]              The queue id of the next track if from queue
- * @param    {string}   [nextTrack.nextTrackID]              The Spotify id of the next track if from queue
- * @param    {number}   nextTrack.position                   The position in the session's queue context, needed only if from context queue
- * @param    {object}   nextTrack.track                      The next track's Spotify information
- * @param    {string}   nextTrack.track.id                   The Spotify track id of the next track
- * @param    {number}   nextTrack.track.durationMS           The duration of the track in milliseconds
- * @param    {string}   [nextTrack.track.name]               The name of the track, needed only if from context queue
- * @param    {object}   [nextTrack.track.album]              The album the track is in, needed only if from context queue
- * @param    {string}   [nextTrack.track.album.id]           The Spotify id of the album, needed only if from context queue
- * @param    {string}   [nextTrack.track.album.name]         The name of the album, needed only if from context queue
- * @param    {string}   [nextTrack.track.album.small]        64x64 size of the album artwork, needed only if from context queue
- * @param    {string}   [nextTrack.track.album.medium]       300x300 size of the album artwork, needed only if from context queue
- * @param    {string}   [nextTrack.track.album.large]        640x640 size of the album artwork, needed only if from context queue
- * @param    {object[]} [nextTrack.track.artists]            The track artists, needed only if from context queue
- * @param    {string}   [nextTrack.track.artists.id]         The Spotify id of the track artist, needed only if from context queue
- * @param    {string}   [nextTrack.track.artists.name]       The name of the track artist, needed only if from context queue
+ * @param    {string}   user.id             The user id of the current user
+ * @param    {string}   user.displayName    The display name of the current user
+ * @param    {string}   user.profileImage   The profile image of the current user
+ * @param    {string}   session             The session object to play the next track in
+ * @param    {string}   session.id          The id of the session to play the next track in
+ * @param    {number}   session.totalQueue  The tracks which are next to play in the session
+ * @param    {number}   session.totalPlayed The total amount of played tracks in the session
+ * @param    {number}   session.totalUsers  The total amount of listeners in the session
+ * @param    {object}   [session.coords]    The coordinates of the session the current user is in
+ * @param    {number}   session.coords.lat  The latitude of the gps coordinates
+ * @param    {number}   session.coords.lon  The longitude of the gps coordinates
+ * @param    {string}   session.current     The queue id of the current track playing in the session
+ * @param    {string}   nextQueueID         The queue id of the next track to play
  *
  * @returns  {Promise}
- * @resolves {object}                                        The now playing session with the next track now playing
- * @reject   {Error}                                         The error which caused the next track failure
+ * @resolves {object}                       The now playing session with the next track now playing
+ * @reject   {Error}                        The error which caused the next track failure
  */
 export function nextTrack(
   user: User,
   session: Session,
-  nextTrack: NextTrack,
+  nextQueueID: string,
 ): ThunkAction {
   return async (dispatch, _, {getFirestore}) => {
     dispatch(actions.nextTrackRequest());
@@ -170,97 +83,69 @@ export function nextTrack(
     const sessionPrevRef: FirestoreDocs = sessionRef.collection('previouslyPlayed');
     const sessionQueueRef: FirestoreDocs = sessionRef.collection('queue');
     const sessionUserRef: FirestoreDoc = sessionRef.collection('users').doc(user.id);
-    const geoRef: FirestoreRef = firestore.collection('geo');
-    const geoFirestore = new GeoFirestore(geoRef);
+    // const geoRef: FirestoreRef = firestore.collection('geo');
+    // const geoFirestore = new GeoFirestore(geoRef);
     const {totalQueue, totalPlayed, totalUsers, current, coords} = session;
 
     let batch: FirestoreBatch = firestore.batch();
 
     try {
-      dispatch(addRecentTrack(user.id, current.track));
+      // dispatch(addRecentTrack(user.id, current.track));
 
+      const [currentDoc, nextDoc] = await Promise.all(
+        [
+          sessionQueueRef.doc(current).get(),
+          sessionQueueRef.doc(nextQueueID).get(),
+        ],
+      );
+
+      if (!currentDoc.exists || !nextDoc.exists) {
+        throw new Error('Unable to retrieve tracks from Firestore');
+      }
+
+      batch.update(sessionQueueRef.doc(current), {isCurrent: true});
       batch.update(sessionUserRef, {progress: 0, paused: false});
-      batch.delete(sessionQueueRef.doc(current.id));
       batch.set(
-        sessionPrevRef.doc(current.id),
+        sessionPrevRef.doc(current),
         {
-          id: current.id,
-          trackID: current.track.id,
-          userID: current.userID,
-          totalLikes: current.totalLikes,
-          prevTrackID: current.prevTrackID,
-          nextTrackID: nextTrack.id,
+          id: current,
+          userID: currentDoc.data().user.id,
+          totalLikes: currentDoc.data().totalLikes,
+          prevQueueID: currentDoc.data().prevQueueID,
+          prevTrackID: currentDoc.data().prevTrackID,
+          nextTrackID: currentDoc.data().nextTrackID,
+          nextQueueID: currentDoc.data().nextQueueID,
+          track: {...currentDoc.data().track},
         },
       );
 
-      if (!nextTrack.id) {
-        const queueDoc: FirestoreDoc = sessionQueueRef.doc();
-        const queueID: string = queueDoc.id;
-        nextTrack = updateObject(nextTrack, {id: queueID});
-
-        batch.set(
-          sessionQueueRef.doc(queueID),
-          {
-            user,
-            id: nextTrack.id,
-            added: true,
-            prevTrackID: current.id,
-            nextTrackID: null,
-            totalLikes: 0,
-            likes: [],
-            track: nextTrack.track,
-          },
-        );
-      };
-
+      batch.delete(sessionQueueRef.doc(current));
       batch.update(
         sessionRef,
         {
           progress: 0,
-          currentQueueID: nextTrack.id,
-          currentTrackID: nextTrack.track.id,
+          currentQueueID: nextQueueID,
+          currentTrackID: nextDoc.data().track.id,
           timeLastPlayed: moment().format('ddd, MMM D, YYYY, h:mm:ss a'),
           paused: false,
           'totals.previouslyPlayed': totalPlayed + 1,
-          ...(nextTrack.prevTrackID
-            ? {'totals.queue': totalQueue - 1}
-            : {'context.position': nextTrack.position + 1}
-          ),
+          'totals.queue': totalQueue - 1,
         },
       );
 
       const promises = [
         batch.commit(),
         Spotify.playURI(`spotify:track:${nextTrack.track.id}`, 0, 0),
-        ...(coords
-          ? [geoFirestore.set(
-            session.id,
-            {
-              id: session.id,
-              currentQueueID: nextTrack.id,
-              currentTrackID: nextTrack.track.id,
-              coordinates: new firestore.GeoPoint(coords.lat, coords.lon),
-              totalListeners: totalUsers,
-              type: 'session',
-              owner: {
-                id: user.id,
-                name: user.displayName,
-                image: user.profileImage,
-              },
-            },
-          )]
-          : []
-        ),
       ];
 
       await Promise.all(promises);
       dispatch(
         actions.nextTrackSuccess(
-          nextTrack.id,
-          nextTrack.track.id,
-          nextTrack.track.durationMS,
-          nextTrack.nextQueueID,
-          nextTrack.nextTrackID,
+          nextQueueID,
+          nextDoc.data().track.id,
+          nextDoc.data().track.durationMS,
+          nextDoc.data().nextQueueID,
+          nextDoc.data().nextTrackID,
         ),
       );
     } catch (err) {

--- a/app/actions/player/NextTrack/reducers.js
+++ b/app/actions/player/NextTrack/reducers.js
@@ -56,17 +56,13 @@ export function success(
   action: Action,
 ): State {
   const {currentQueueID: prevQueueID, currentTrackID: prevTrackID} = state;
-  const {durationMS, nextQueueID, nextTrackID, currentQueueID, currentTrackID} = action;
+  const {type, ...rest} = action;
   
   return updateObject(state, {
+    ...rest,
     lastUpdated,
     prevQueueID,
     prevTrackID,
-    currentQueueID,
-    currentTrackID,
-    durationMS,
-    nextQueueID,
-    nextTrackID,
     progress: 0,
     skippingNext: false,
     paused: false,

--- a/app/actions/queue/AddQueueTracks/reducers.js
+++ b/app/actions/queue/AddQueueTracks/reducers.js
@@ -52,7 +52,7 @@ export function addSingleTrack(state, action) {
 export function addQueueTracks(state, action) {
   const {tracks} = action;
   
-  let {queueByID} = state;
+  let {queueByID, userQueue} = state;
 
   Object.values(tracks).forEach(track => {
     const addedTrack = singleTrack(queueByID[track.id], {...action, track});
@@ -62,7 +62,7 @@ export function addQueueTracks(state, action) {
   return updateObject(state, {
     lastUpdated,
     queueByID,
-    totalQueue: Object.keys(queueByID).length,
+    totalQueue: userQueue.length,
     error: null,
   });
 }

--- a/app/actions/queue/GetUserQueue/index.js
+++ b/app/actions/queue/GetUserQueue/index.js
@@ -112,7 +112,9 @@ export function getUserQueue(
                     ),
                   );
 
-                  if (!queueTrack.isCurrent) {
+                  if (queueTrack.isCurrent) {
+                    dispatch(removeQueueTrack(queueTrack.id));
+                  } else {
                     dispatch(actions.getUserQueueSuccess([queueTrack.id], unsubscribe));
                   }
                 }
@@ -136,13 +138,15 @@ export function getUserQueue(
                   ),
                 );
 
-                if (!queueTrack.isCurrent) {
+                if (queueTrack.isCurrent) {
+                  dispatch(removeQueueTrack(queueTrack.id));
+                } else {
                   dispatch(actions.getUserQueueSuccess([queueTrack.id], unsubscribe));
                 }
               }
 
               if (change.type === 'removed') {
-                dispatch(removeQueueTrack(queueTrack.id));
+                dispatch(removeQueueTrack(queueTrack.id, true));
               }
             });
           },

--- a/app/actions/queue/GetUserQueue/reducers.js
+++ b/app/actions/queue/GetUserQueue/reducers.js
@@ -54,6 +54,26 @@ export function success(
 ): State {
   const {queueByID, userQueue: oldQueue} = state;
   const {unsubscribe, queue: userQueue} = action;
+  const newQueue: Array<string> = Array.isArray(userQueue) && Array.isArray(oldQueue)
+    ? [...oldQueue, ...userQueue]
+      .filter((el, i, arr) => i === arr.indexOf(el))
+      .sort((a, b) => {
+        if (
+          typeof queueByID !== 'undefined'
+          && typeof queueByID[a].seconds === 'number'
+          && typeof queueByID[b].seconds === 'number'
+          && typeof queueByID[a].nanoseconds === 'number'
+          && typeof queueByID[b].nanoseconds === 'number'
+        ) {
+          const {seconds: secA, nanoseconds: nanoA} = queueByID[a];
+          const {seconds: secB, nanoseconds: nanoB} = queueByID[b];
+          return secA < secB ? -1 : secA > secB ? 1 : nanoA < nanoB ? -1 : nanoA > nanoB ? 1 : 0;
+        } else {
+          return 0;
+        }
+      })
+    : [];
+
   const updates = (
     Array.isArray(userQueue)
     && typeof unsubscribe === 'function'
@@ -63,23 +83,8 @@ export function success(
       unsubscribe,
       fetchingQueue: false,
       error: null,
-      userQueue: [...oldQueue, ...userQueue]
-        .filter((el, i, arr) => i === arr.indexOf(el))
-        .sort((a, b) => {
-          if (
-            typeof queueByID !== 'undefined'
-            && typeof queueByID[a].seconds === 'number'
-            && typeof queueByID[b].seconds === 'number'
-            && typeof queueByID[a].nanoseconds === 'number'
-            && typeof queueByID[b].nanoseconds === 'number'
-          ) {
-            const {seconds: secA, nanoseconds: nanoA} = queueByID[a];
-            const {seconds: secB, nanoseconds: nanoB} = queueByID[b];
-            return secA < secB ? -1 : secA > secB ? 1 : nanoA < nanoB ? -1 : nanoA > nanoB ? 1 : 0;
-          } else {
-            return 0;
-          }
-        }),
+      userQueue: newQueue,
+      totalQueue: newQueue.length,
     }
     : {};
 

--- a/app/actions/queue/QueueTrack/index.js
+++ b/app/actions/queue/QueueTrack/index.js
@@ -108,7 +108,7 @@ export function queueTrack(
     let batch: FirestoreBatch = firestore.batch();
 
     try {
-      if (totalQueue === 1) {
+      if (totalQueue === 0) {
         dispatch(updatePlayer({nextQueueID: queueID, nextTrackID: track.id}));
       }
 

--- a/app/actions/queue/RemoveQueueTrack/actions.test.js
+++ b/app/actions/queue/RemoveQueueTrack/actions.test.js
@@ -12,11 +12,14 @@ import {type Action} from '../../../reducers/queue';
 describe('remove queue track action creator', () => {
   it('creates action to remove a queue track in a session', () => {
     const queueID: string = 'foo';
+    const removeTrack: boolean = true;
     const expectedAction: Action = {
       type: types.REMOVE_QUEUE_TRACK,
       queueID,
+      removeTrack,
     };
 
-    expect(actions.removeQueueTrack(queueID)).toStrictEqual(expectedAction);
+    expect(actions.removeQueueTrack(queueID, removeTrack)).toStrictEqual(expectedAction);
+    expect(actions.removeQueueTrack(queueID)).toStrictEqual({...expectedAction, removeTrack: false});
   });
 });

--- a/app/actions/queue/RemoveQueueTrack/index.js
+++ b/app/actions/queue/RemoveQueueTrack/index.js
@@ -26,9 +26,11 @@ import {type Action} from '../../../reducers/queue';
  */
 export function removeQueueTrack(
   queueID: string,
+  removeTrack?: boolean = false,
 ): Action {
   return {
     type: types.REMOVE_QUEUE_TRACK,
     queueID,
+    removeTrack,
   };
 }

--- a/app/actions/queue/RemoveQueueTrack/reducers.js
+++ b/app/actions/queue/RemoveQueueTrack/reducers.js
@@ -23,27 +23,30 @@ import {
  * 
  * @author Aldo Gonzalez <aldo@tunerinc.com>
  * 
- * @param   {object} state          The Redux state
- * @param   {object} action         The Redux action
- * @param   {string} action.type    The type of Redux action
- * @param   {string} action.queueID The Brassroots id of the queue track to remove
+ * @param   {object}  state              The Redux state
+ * @param   {object}  action             The Redux action
+ * @param   {string}  action.type        The type of Redux action
+ * @param   {string}  action.queueID     The Brassroots id of the queue track to remove
+ * @param   {boolean} action.removeTrack Whether to remove the cached track information on top of removing from user queue
  * 
- * @returns {object}                The state with the queue track removed in a session
+ * @returns {object}                     The state with the queue track removed in a session
  */
 export function removeQueueTrack(
   state: State,
   action: Action,
 ): State {
   const {userQueue: oldQueue, queueByID} = state;
-  const {queueID} = action;
+  const {queueID, removeTrack} = action;
   const userQueue = Array.isArray(oldQueue) ? oldQueue.filter(id => id !== queueID) : oldQueue;
   const updates = Array.isArray(userQueue) && typeof queueID === 'string' && typeof queueByID === 'object'
     ? {
       userQueue,
       lastUpdated,
-      queueByID: userQueue.reduce((obj, key) => updateObject(obj, {[key]: queueByID[key]}), {}),
       totalQueue: userQueue.length,
       error: null,
+      queueByID: removeTrack
+        ? userQueue.reduce((obj, key) => updateObject(obj, {[key]: queueByID[key]}), {})
+        : {...queueByID},
     }
     : {};
 

--- a/app/actions/queue/RemoveQueueTrack/reducers.test.js
+++ b/app/actions/queue/RemoveQueueTrack/reducers.test.js
@@ -16,6 +16,7 @@ describe('remove queue track reducer', () => {
 
   it('should handle REMOVE_QUEUE_TRACK', () => {
     const queueID: string = 'foo';
+    const removeTrack: boolean = true;
 
     expect(
       reducer(
@@ -48,6 +49,71 @@ describe('remove queue track reducer', () => {
           },
         },
         actions.removeQueueTrack(queueID),
+      )
+    )
+      .toStrictEqual(
+        {
+          ...initialState,
+          userQueue: ['bar', 'xyz'],
+          totalQueue: 2,
+          lastUpdated: moment().format('ddd, MMM D, YYYY, h:mm:ss a'),
+          queueByID: {
+            'foo': {
+              id: 'foo',
+              trackID: 'foo',
+              userID: 'foo',
+              totalLikes: 0,
+              liked: false,
+            },
+            'bar': {
+              id: 'bar',
+              trackID: 'bar',
+              userID: 'bar',
+              totalLikes: 0,
+              liked: false,
+            },
+            'xyz': {
+              id: 'xyz',
+              trackID: 'xyz',
+              userID: 'xyz',
+              totalLikes: 0,
+              liked: false,
+            },
+          },
+        },
+      );
+
+    expect(
+      reducer(
+        {
+          ...initialState,
+          userQueue: ['foo', 'bar', 'xyz'],
+          totalQueue: 3,
+          queueByID: {
+            'foo': {
+              id: 'foo',
+              trackID: 'foo',
+              userID: 'foo',
+              totalLikes: 0,
+              liked: false,
+            },
+            'bar': {
+              id: 'bar',
+              trackID: 'bar',
+              userID: 'bar',
+              totalLikes: 0,
+              liked: false,
+            },
+            'xyz': {
+              id: 'xyz',
+              trackID: 'xyz',
+              userID: 'xyz',
+              totalLikes: 0,
+              liked: false,
+            },
+          },
+        },
+        actions.removeQueueTrack(queueID, removeTrack),
       )
     )
       .toStrictEqual(

--- a/app/components/PlayerTabBar/index.js
+++ b/app/components/PlayerTabBar/index.js
@@ -70,7 +70,15 @@ class PlayerTabBar extends React.Component {
     const {
       pausePlayer,
       startPlayer,
-      player: {paused, seeking, progress, currentQueueID, skippingPrev, error: playerError},
+      player: {
+        paused,
+        seeking,
+        progress,
+        currentQueueID,
+        skippingPrev,
+        skippingNext,
+        error: playerError,
+      },
       queue: {context},
       sessions: {currentSessionID, sessionsByID},
       tracks: {fetchingMostPlayed, error: tracksError},
@@ -84,7 +92,8 @@ class PlayerTabBar extends React.Component {
         seeking: oldSeeking,
         progress: oldProgress,
         currentQueueID: oldCurrentID,
-        skippingPrev: oldSkipping,
+        skippingPrev: oldSkippingPrev,
+        skippingNext: oldSkippingNext,
       },
     } = prevProps;
     const currentSession = sessionsByID[currentSessionID];
@@ -98,7 +107,13 @@ class PlayerTabBar extends React.Component {
       this.tabBarBGColor = '#28282b';
     }
 
-    if (oldSkipping && !skippingPrev && !playerError && !paused) {
+    if (
+      !playerError
+      && !paused
+      && (
+        (oldSkippingPrev && !skippingPrev) || (oldSkippingNext && !skippingNext)
+      )
+    ) {
       clearInterval(this.progressInterval);
       this.progressInterval = null;
       this.progressInterval = setInterval(this.setProgress, 985);

--- a/app/containers/LiveSessionView/index.js
+++ b/app/containers/LiveSessionView/index.js
@@ -307,7 +307,21 @@ class LiveSessionView extends React.Component {
   }
 
   skipNext() {
-    console.log('skip next pressed');
+    const {
+      nextTrack,
+      player: {nextQueueID, currentQueueID: current},
+      queue: {totalQueue},
+      sessions: {currentSessionID, sessionsByID},
+      users: {currentUserID, usersByID},
+    } = this.props;
+    const {displayName, profileImage} = usersByID[currentUserID];
+    const {totalPlayed, totalListeners: totalUsers} = sessionsByID[currentSessionID];
+
+    nextTrack(
+      {displayName, profileImage, id: currentUserID},
+      {totalQueue, totalPlayed, totalUsers, current, id: currentSessionID},
+      nextQueueID,
+    );
   }
 
   skipPrev() {

--- a/app/reducers/player.js
+++ b/app/reducers/player.js
@@ -8,6 +8,7 @@
 import moment from 'moment';
 import updateObject from '../utils/updateObject';
 import {type Action as TrackAction} from './tracks';
+import {type Action as QueueAction} from './queue';
 import {type Firebase} from '../utils/firebaseTypes';
 import * as types from '../actions/player/types';
 
@@ -28,7 +29,7 @@ import {updatePlayer} from '../actions/player/UpdatePlayer/reducers';
 
 export const lastUpdated: string = moment().format('ddd, MMM D, YYYY, h:mm:ss a');
 
-type DispatchAction = Action | TrackAction;
+type DispatchAction = Action | TrackAction | QueueAction;
 type GetState = () => State;
 type PromiseAction = Promise<DispatchAction>;
 type ThunkAction = (dispatch: Dispatch, getState: GetState, firebase: Firebase) => any;

--- a/app/reducers/queue.js
+++ b/app/reducers/queue.js
@@ -70,6 +70,7 @@ type Action = {
   +queue?: ?Array<string>,
   +unsubscribe?: () => void,
   +updates?: Updates,
+  +removeTrack?: boolean,
 };
 
 type State = {

--- a/ios/brassroots/Info.plist
+++ b/ios/brassroots/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.5</string>
+	<string>0.0.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>


### PR DESCRIPTION
### Description

The main purpose of this pull request is to add the ability to play the next track in the user queue.

#### Test Plan

```
npm test app/actions/player/NextTrack/
```

### Motivation and Context

The purpose for making this action creator is to allow the current user to play the song they have queued up in their session. Currently, the user is only able to play the previous song, or a new song entirely. With these updates, the user will now have full playing functionality able to be used.

### How Has This Been Tested?

Thus far, the synchronous action creators and the reducer case functions have their unit tests passing. I've tested manually as well by playing the next track in varying ways, while including the other functionality throughout the process to make sure everything is working together in harmony.

### Screenshots (if appropriate)

N/A

### Types of Changes

- [ ] Documentation
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

#### Bug Fixes

N/A

#### Breaking Changes

N/A

### Checklist

- [x] My code follows the code style of this project
- [x] My change requires tests to be written
- [x] I have written the tests necessary for my code
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly