### PR TITLE
Fix player/queue bugs

### DIFF
--- a/app/actions/player/NextTrack/index.js
+++ b/app/actions/player/NextTrack/index.js
@@ -16,6 +16,7 @@ import Spotify from 'rn-spotify-sdk';
 import updateObject from '../../../utils/updateObject';
 import * as actions from './actions';
 import {removeQueueTrack} from '../../queue/RemoveQueueTrack';
+import {updatePlayer} from '../UpdatePlayer';
 import {type TrackArtist} from '../../../reducers/tracks';
 import {type ThunkAction} from '../../../reducers/player';
 import {
@@ -104,7 +105,7 @@ export function nextTrack(
         throw new Error('Unable to retrieve tracks from Firestore');
       }
 
-      batch.update(sessionQueueRef.doc(current), {isCurrent: true});
+      batch.update(sessionQueueRef.doc(nextQueueID), {isCurrent: true});
       batch.update(sessionUserRef, {progress: 0, paused: false});
       batch.set(
         sessionPrevRef.doc(current),

--- a/app/actions/player/PlayTrack/reducers.js
+++ b/app/actions/player/PlayTrack/reducers.js
@@ -46,7 +46,6 @@ export function success(
     durationMS,
     prevQueueID: currentQueueID === prevQueueID ? null : prevQueueID,
     prevTrackID: currentTrackID === prevTrackID ? null : prevTrackID,
-    progress: 0,
     attemptingToPlay: false,
     paused: false,
     error: null,

--- a/app/actions/player/PreviousTrack/index.js
+++ b/app/actions/player/PreviousTrack/index.js
@@ -130,6 +130,8 @@ export function previousTrack(
     // const geoFirestore = new GeoFirestore(geoRef);
     const {coords, current, totalPlayed} = session;
 
+    let batch: FirestoreBatch = firestore.batch();
+
     try {
       // dispatch(addRecentTrack(user.id, current.track));
 
@@ -141,8 +143,6 @@ export function previousTrack(
           sessionQueueRef.doc(current.id).get(),
         ],
       );
-
-      let batch: FirestoreBatch = firestore.batch();
 
       if (!prevDoc.exists || !currentDoc.exists) {
         throw new Error('Unable to retrieve tracks from Firestore.');

--- a/app/actions/player/TogglePause/index.js
+++ b/app/actions/player/TogglePause/index.js
@@ -77,10 +77,10 @@ export function togglePause(
       const timeLastPlayed: string = moment().format('ddd, MMM D, YYYY, h:mm:ss a');
 
       if (typeof playbackState.position === 'number') {
-        batch.update(sessionUserRef, {paused, progress: session.progress + 1000});
+        batch.update(sessionUserRef, {paused, progress: session.progress});
 
         if (ownerID === userID) {
-          batch.update(sessionRef, {timeLastPlayed, paused, progress: session.progress + 1000});
+          batch.update(sessionRef, {timeLastPlayed, paused, progress: session.progress});
         }
       } else {
         batch.update(sessionUserRef, {paused});

--- a/app/actions/queue/GetUserQueue/index.js
+++ b/app/actions/queue/GetUserQueue/index.js
@@ -35,6 +35,7 @@ import {
  *
  * @param    {string}  userID    The user id of the current user
  * @param    {string}  sessionID The session id to get the queue from
+ * @param    {boolean} isOwner   Whether the current user is the owner of the session
  *
  * @return   {Promise}
  * @resolves {object}            The queue from the now playing session
@@ -43,7 +44,7 @@ import {
 export function getUserQueue(
   userID: string,
   sessionID: string,
-  current: ?string,
+  isOwner: boolean,
 ): ThunkAction {
   return async (dispatch, getState, {getFirestore}) => {
     dispatch(actions.request());
@@ -113,15 +114,18 @@ export function getUserQueue(
 
                   if (queueTrack.isCurrent) {
                     dispatch(removeQueueTrack(queueTrack.id));
-                    dispatch(
-                      updatePlayer(
-                        {
-                          currentTrackID: track.id,
-                          currentQueueID: queueTrack.id,
-                          durationMS: track.durationMS,
-                        },
-                      ),
-                    );
+
+                    if (!isOwner) {
+                      dispatch(
+                        updatePlayer(
+                          {
+                            currentTrackID: track.id,
+                            currentQueueID: queueTrack.id,
+                            durationMS: track.durationMS,
+                          },
+                        ),
+                      );
+                    }
                   } else {
                     dispatch(
                       actions.success(
@@ -162,15 +166,20 @@ export function getUserQueue(
 
                 if (queueTrack.isCurrent) {
                   dispatch(removeQueueTrack(queueTrack.id));
-                  dispatch(
-                    updatePlayer(
-                      {
-                        currentTrackID: track.id,
-                        currentQueueID: queueTrack.id,
-                        durationMS: track.durationMS,
-                      },
-                    ),
-                  );
+
+                  if (!isOwner) {
+                    dispatch(
+                      updatePlayer(
+                        {
+                          currentTrackID: track.id,
+                          currentQueueID: queueTrack.id,
+                          durationMS: track.durationMS,
+                          nextTrackID: queueTrack.nextTrackID,
+                          nextQueueID: queueTrack.nextQueueID,
+                        },
+                      ),
+                    );
+                  }
                 } else {
                   dispatch(
                     actions.success(

--- a/app/actions/queue/QueueTrack/index.js
+++ b/app/actions/queue/QueueTrack/index.js
@@ -108,6 +108,7 @@ export function queueTrack(
     let batch: FirestoreBatch = firestore.batch();
 
     try {
+      console.log(totalQueue)
       if (totalQueue === 0) {
         dispatch(updatePlayer({nextQueueID: queueID, nextTrackID: track.id}));
       }

--- a/app/components/AddToQueueDialog/index.js
+++ b/app/components/AddToQueueDialog/index.js
@@ -44,41 +44,41 @@ export default class AddToQueueDialog extends React.Component<Props, State> {
         toValue: 10,
         duration: 1,
         easing: Easing.linear,
-        useNativeDriver: true,
+        useNativeDriver: false,
       }),
       Animated.timing(this.containerOpacity, {
         toValue: 0.9,
         duration: 230,
         delay: 1,
         easing: Easing.linear,
-        useNativeDriver: true,
+        useNativeDriver: false,
       }),
       Animated.timing(this.contentOpacity, {
         toValue: 1,
         duration: 230,
         delay: 1,
         easing: Easing.linear,
-        useNativeDriver: true,
+        useNativeDriver: false,
       }),
       Animated.timing(this.contentOpacity, {
         toValue: 0,
         duration: 230,
         delay: 1001,
         easing: Easing.linear,
-        useNativeDriver: true,
+        useNativeDriver: false,
       }),
       Animated.timing(this.containerOpacity, {
         toValue: 0,
         duration: 230,
         easing: Easing.linear,
-        useNativeDriver: true,
+        useNativeDriver: false,
       }),
       Animated.timing(this.containerIndex, {
         toValue: -10,
         duration: 1,
         delay: 1,
         easing: Easing.linear,
-        useNativeDriver: true,
+        useNativeDriver: false,
       })
     ]).start();
 

--- a/app/components/PlayerTabBar/index.js
+++ b/app/components/PlayerTabBar/index.js
@@ -78,11 +78,12 @@ class PlayerTabBar extends React.Component {
         progress,
         durationMS,
         currentQueueID,
+        nextQueueID,
         skippingPrev,
         skippingNext,
         error: playerError,
       },
-      queue: {context},
+      queue: {context, userQueue},
       sessions: {currentSessionID},
       tracks: {fetching, error: tracksError},
       users: {currentUserID},
@@ -91,7 +92,7 @@ class PlayerTabBar extends React.Component {
       entities: {sessions: oldSessions},
       sessions: {currentSessionID: oldSessionID},
       tracks: {fetching: oldFetching},
-      queue: {context: oldContext},
+      queue: {context: oldContext, userQueue: oldQueue},
       player: {
         paused: oldPaused,
         seeking: oldSeeking,
@@ -111,6 +112,14 @@ class PlayerTabBar extends React.Component {
 
     if (!currentSessionID && this.tabBarBGColor !== '#28282b') {
       this.tabBarBGColor = '#28282b';
+    }
+
+    if (userQueue.length === 0 && oldQueue.length > 0) {
+      updatePlayer({nextTrackID: null, nextQueueID: null});
+    }
+
+    if (userQueue.length === 1 && userQueue[0].id !== nextQueueID) {
+      updatePlayer({nextTrackID: userQueue[0].trackID, nextQueueID: userQueue[0].id});
     }
 
     if (

--- a/app/containers/EditProfileView/index.js
+++ b/app/containers/EditProfileView/index.js
@@ -310,7 +310,7 @@ class EditProfileView extends React.Component {
             {height: headerHeight, shadowOpacity: headerShadowOpacity},
           ]}
         >
-          {(trackFetch.includes('favorite') || coverImage === '') && <View></View>}
+          {(typeof coverImage !== 'string' || coverImage === '') && <View></View>}
           {coverImageExists &&
             <Animated.View style={[styles.headerBackground, {height: headerHeight}]}>
               <Animated.Image

--- a/app/containers/LibrarySingleAlbumView/index.js
+++ b/app/containers/LibrarySingleAlbumView/index.js
@@ -107,8 +107,8 @@ class LibrarySingleAlbumView extends React.Component {
     const {selectedTrack} = this.state;
     const {
       queueTrack,
-      entities: {queueTracks, sessions, tracks, users},
-      player: {currentQueueID},
+      entities: {sessions, tracks, users},
+      player: {currentQueueID, currentTrackID},
       queue: {userQueue, totalUserQueue: totalQueue},
       sessions: {currentSessionID},
       users: {currentUserID},
@@ -123,7 +123,7 @@ class LibrarySingleAlbumView extends React.Component {
       if (!songInQueue) {
         const track = tracks.byID[selectedTrack];
         const prevQueueID = userQueue.length ? userQueue[userQueue.length - 1].id : currentQueueID;
-        const prevTrackID = queueTracks.byID[prevQueueID];
+        const prevTrackID = userQueue.length ? userQueue[userQueue.length - 1].trackID : currentTrackID;
         const session = {prevQueueID, prevTrackID, totalQueue, id: currentSessionID};
         const user = {displayName, profileImage, id: currentUserID};
 

--- a/app/containers/LibraryTracksView/index.js
+++ b/app/containers/LibraryTracksView/index.js
@@ -239,8 +239,8 @@ class LibraryTracksView extends React.Component {
     const {selectedTrack} = this.state;
     const {
       queueTrack,
-      entities: {queueTracks, sessions, tracks, users},
-      player: {currentQueueID},
+      entities: {sessions, tracks, users},
+      player: {currentQueueID, currentTrackID},
       queue: {userQueue, totalUserQueue: totalQueue},
       sessions: {currentSessionID},
       users: {currentUserID},
@@ -255,7 +255,7 @@ class LibraryTracksView extends React.Component {
       if (!songInQueue) {
         const track = tracks.byID[selectedTrack];
         const prevQueueID = userQueue.length ? userQueue[userQueue.length - 1].id : currentQueueID;
-        const prevTrackID = queueTracks.byID[prevQueueID];
+        const prevTrackID = userQueue.length ? userQueue[userQueue.length - 1].trackID : currentTrackID;
         const session = {prevQueueID, prevTrackID, totalQueue, id: currentSessionID};
         const user = {displayName, profileImage, id: currentUserID};
 

--- a/app/containers/LiveSessionView/index.js
+++ b/app/containers/LiveSessionView/index.js
@@ -127,13 +127,15 @@ class LiveSessionView extends React.Component {
       getSessionInfo,
       getUserQueue,
       chat: {fetching: chatFetching, chatUnsubscribe},
-      player: {currentQueueID},
+      entities: {sessions},
       queue: {fetching: queueFetching, unsubscribe: queueUnsubscribe},
       sessions: {currentSessionID, fetching: sessionFetching, infoUnsubscribe},
       users: {currentUserID},
     } = this.props;
     
     if (currentSessionID) {
+      const isOwner = sessions.byID[currentSessionID].ownerID === currentUserID;
+
       // if (!fetchedChat && !fetchingChat) {
       //   this.setState({fetchedChat: true});
       //   getChat(currentSessionID);
@@ -146,7 +148,7 @@ class LiveSessionView extends React.Component {
 
       if (!fetchedQueue && !queueFetching.includes('queue') && !queueUnsubscribe) {
         this.setState({fetchedQueue: true});
-        getUserQueue(currentUserID, currentSessionID, currentQueueID);
+        getUserQueue(currentUserID, currentSessionID, isOwner);
       }
     }
   }
@@ -158,14 +160,17 @@ class LiveSessionView extends React.Component {
       getSessionInfo,
       getUserQueue,
       chat: {fetching: chatFetching, chatUnsubscribe},
-      player: {progress, currentQueueID},
+      entities: {sessions},
+      player: {progress},
       queue: {userQueue, fetching: queueFetching, unsubscribe: queueUnsubscribe},
       sessions: {currentSessionID, fetching: sessionFetching, infoUnsubscribe},
       users: {currentUserID},
     } = this.props;
     const {player: {progress: newProgress}} = nextProps;
 
-    if (currentSessionID) {
+    if (currentSessionID && sessions.allIDs.includes(currentSessionID)) {
+      const isOwner = sessions.byID[currentSessionID].ownerID === currentUserID;
+
       // if (!fetchedChat && !fetchingChat) {
       //   this.setState({fetchedChat: true});
       //   getChat(currentSessionID);
@@ -178,7 +183,7 @@ class LiveSessionView extends React.Component {
 
       if (!fetchedQueue && !queueFetching.includes('queue') && !queueUnsubscribe) {
         this.setState({fetchedQueue: true});
-        getUserQueue(currentUserID, currentSessionID, currentQueueID);
+        getUserQueue(currentUserID, currentSessionID, isOwner);
       }
     }
 
@@ -254,6 +259,12 @@ class LiveSessionView extends React.Component {
     const owner = users.byID[sessions.byID[currentSessionID].ownerID];
 
     setTimeout(Actions.pop, 200);
+
+    this.setState({
+      fetchedChat: false,
+      fetchedInfo: false,
+      fetchedQueue: false,
+    });
 
     leaveSession(
       currentUserID,

--- a/app/containers/PlaylistView/index.js
+++ b/app/containers/PlaylistView/index.js
@@ -185,8 +185,8 @@ class PlaylistView extends React.Component {
     const {selectedTrack} = this.state;
     const {
       queueTrack,
-      entities: {queueTracks, sessions, tracks, users},
-      player: {currentQueueID},
+      entities: {sessions, tracks, users},
+      player: {currentQueueID, currentTrackID},
       queue: {userQueue, totalUserQueue: totalQueue},
       sessions: {currentSessionID},
       users: {currentUserID},
@@ -201,7 +201,7 @@ class PlaylistView extends React.Component {
       if (!songInQueue) {
         const track = tracks.byID[selectedTrack];
         const prevQueueID = userQueue.length ? userQueue[userQueue.length - 1].id : currentQueueID;
-        const prevTrackID = queueTracks.byID[prevQueueID];
+        const prevTrackID = userQueue.length ? userQueue[userQueue.length - 1].trackID : currentTrackID;
         const session = {prevQueueID, prevTrackID, totalQueue, id: currentSessionID};
         const user = {displayName, profileImage, id: currentUserID};
 


### PR DESCRIPTION
### Description

The main purpose of this pull request is to fix a few errors concerning the playing or queuing of music. One bug this PR aims to fix is one where the playing controls to play the next or previous track are disabled when they shouldn't be. Another bug is when the current user is attempting to queue more than one song after another. The last bug is the next track not playing when the current song has played all the way through.

#### Test Plan

N/A

### Motivation and Context

We want users to be able to listen to music as they would want to in a session without anything impeding them from doing so. This includes listening to music in any fashion as well as queuing the songs you may want to.

### How Has This Been Tested?

I've gone through various use cases to ensure the functionality is operating as it should be.

### Screenshots (if appropriate)

N/A

### Types of Changes

- ~~Documentation~~
- Bug fix
- ~~New feature~~
- ~~Breaking change~~

#### Bug Fixes

- #37 ([d8a582a](https://github.com/tunerinc/brassroots/pull/40/commits/e87391dbd9d576c6e640b888cde06517255690d1) by @therealaldo)
- #38 ([d8a582a](https://github.com/tunerinc/brassroots/pull/40/commits/e87391dbd9d576c6e640b888cde06517255690d1) by @therealaldo)
- #39 ([d8a582a](https://github.com/tunerinc/brassroots/pull/40/commits/e87391dbd9d576c6e640b888cde06517255690d1) by @therealaldo)

### Checklist

- [x] My code follows the code style of this project
- ~~My change requires tests to be written~~
- ~~I have written the tests necessary for my code~~
- ~~My change requires a change to the documentation~~
- ~~I have updated the documentation accordingly~~