### PR TITLE
Fix play track bug while in session

### DIFF
--- a/app/components/PlayerTabBar/index.js
+++ b/app/components/PlayerTabBar/index.js
@@ -123,6 +123,15 @@ class PlayerTabBar extends React.Component {
     }
 
     if (
+      typeof currentSessionID === 'string'
+      && typeof oldSessionID === 'string'
+      && currentSessionID === oldSessionID
+      && currentQueueID !== oldCurrentID
+    ) {
+      updatePlayer({progress: 0});
+    }
+
+    if (
       !playerError
       && !paused
       && (

--- a/app/containers/LibraryTracksView/index.js
+++ b/app/containers/LibraryTracksView/index.js
@@ -197,14 +197,12 @@ class LibraryTracksView extends React.Component {
               id: session.id,
               totalPlayed: session.totalPlayed,
               current: {
-                prevQueueID,
-                prevTrackID,
                 nextQueueID,
                 nextTrackID,
                 track,
                 id: currentQueueID,
-                totalLikes: currentQueue.totalLikes,
-                userID: currentQueue.userID,
+                totalLikes: queueTrack.totalLikes,
+                userID: queueTrack.userID,
               },
             },
             {

--- a/app/containers/LibraryTracksView/index.js
+++ b/app/containers/LibraryTracksView/index.js
@@ -192,7 +192,7 @@ class LibraryTracksView extends React.Component {
         } else {
           playTrack(
             user,
-            {...trackToPlay, id: null, trackID: track.id},
+            {...trackToPlay, id: null, trackID: trackToPlay.id},
             {
               id: session.id,
               totalPlayed: session.totalPlayed,


### PR DESCRIPTION
### Description

The main purpose of this pull request is to fix a bug where the app crashes when trying to play a new song while in your own session already. The bug occurs when the current user is in their own session listening to music, and taps on another song to listen to in the same session.

#### Test Plan

N/A

### Motivation and Context

We want users to be able to listen to music as they would want to in a session without anything impeding them from doing so. This includes listening to music in any fashion.

### How Has This Been Tested?

I've gone through various use cases to ensure the functionality is operating as it should be.

### Screenshots (if appropriate)

N/A

### Types of Changes

- ~~Documentation~~
- Bug fix
- ~~New feature~~
- ~~Breaking change~~

#### Bug Fixes

- #36 ([7619a1c](https://github.com/tunerinc/brassroots/pull/43/commits/7619a1c040cae314b9c02fe6cf330a4492b5c4d0)  by @therealaldo)

### Checklist

- [x] My code follows the code style of this project