### PR TITLE
Implement change favorite track

### DIFF
--- a/app/components/TrackModal/index.js
+++ b/app/components/TrackModal/index.js
@@ -13,6 +13,7 @@ import styles from './styles';
 type Props = {|
   closeModal: () => void,
   queueTrack: () => void,
+  setFavoriteTrack: () => void,
   name: string,
   artists: string,
   albumName: string,
@@ -20,6 +21,7 @@ type Props = {|
   trackID?: string,
   trackInQueue?: boolean,
   isListenerOwner?: ?boolean,
+  isFavorite?: boolean,
 |};
 
 type State = {||};
@@ -36,6 +38,8 @@ export default class TrackModal extends React.PureComponent<Props, State> {
       trackID,
       trackInQueue,
       isListenerOwner,
+      isFavorite,
+      setFavoriteTrack,
     } = this.props;
 
     if (!trackID) return <View></View>;
@@ -76,6 +80,18 @@ export default class TrackModal extends React.PureComponent<Props, State> {
             </View>
           }
         </View>
+        {!isFavorite &&
+          <View style={styles.option}>
+            <TouchableHighlight
+              style={styles.button}
+              activeOpacity={0.5}
+              underlayColor='#fefefe'
+              onPress={setFavoriteTrack}
+            >
+              <Text style={styles.text}>set as favorite</Text>
+            </TouchableHighlight>
+          </View>
+        }
         <View style={styles.option}>
           <TouchableHighlight
             style={styles.button}

--- a/app/containers/PlaylistView/index.js
+++ b/app/containers/PlaylistView/index.js
@@ -48,6 +48,9 @@ import {queueTrack} from '../../actions/queue/QueueTrack';
 import {createSession} from '../../actions/sessions/CreateSession';
 import {leaveSession} from '../../actions/sessions/LeaveSession';
 
+// Tracks Action Creators
+import {changeFavoriteTrack} from '../../actions/tracks/ChangeFavoriteTrack';
+
 const HEADER_MAX_HEIGHT = 261;
 const HEADER_MIN_HEIGHT = 65;
 const HEADER_SCROLL_DISTANCE = HEADER_MAX_HEIGHT - HEADER_MIN_HEIGHT;
@@ -77,6 +80,7 @@ class PlaylistView extends React.Component {
     this.closeModal = this.closeModal.bind(this);
     this.onScroll = this.onScroll.bind(this);
     this.onPanelDrag = this.onPanelDrag.bind(this);
+    this.handleChangeFavoriteTrack = this.handleChangeFavoriteTrack.bind(this);
 
     this._deltaY = new Animated.Value(0);
     this._onEndReached = debounce(this.onEndReached, 0);
@@ -316,6 +320,7 @@ class PlaylistView extends React.Component {
     ) return <View></View>;
 
     const entity = type === 'track' ? tracks.byID[item] : playlists.byID[item];
+    const {favoriteTrackID} = users.byID[currentUserID];
 
     switch (type) {
       case 'track': {
@@ -338,6 +343,8 @@ class PlaylistView extends React.Component {
             albumImage={entity.album.medium}
             trackInQueue={songQueued}
             isListenerOwner={isListenerOwner}
+            isFavorite={favoriteTrackID === entity.id}
+            setFavoriteTrack={this.handleChangeFavoriteTrack(entity.id)}
           />
         );
       }
@@ -397,6 +404,12 @@ class PlaylistView extends React.Component {
       this.setState({scrollEnabled: false, isOpen: true});
       this.refs['TrackList'].getScrollResponder().scrollTo({x: 0, y: 0});
     }
+  }
+
+  handleChangeFavoriteTrack = trackID => () => {
+    const {changeFavoriteTrack, users: {currentUserID}} = this.props;
+    changeFavoriteTrack(currentUserID, trackID);
+    this.closeModal();
   }
 
   render() {
@@ -655,6 +668,7 @@ class PlaylistView extends React.Component {
 }
 
 PlaylistView.propTypes = {
+  changeFavoriteTrack: PropTypes.func.isRequired,
   createSession: PropTypes.func.isRequired,
   entities: PropTypes.object.isRequired,
   getPlaylistTracks: PropTypes.func.isRequired,
@@ -687,6 +701,7 @@ function mapStateToProps({entities, player, playlists, queue, sessions, settings
 
 function mapDispatchToProps(dispatch) {
   return bindActionCreators({
+    changeFavoriteTrack,
     createSession,
     getPlaylistTracks,
     leaveSession,


### PR DESCRIPTION
### Description

The main purpose of this pull request is to add the ability for the current user to change their favorite track after they have signed up.

#### Test Plan

N/A

### Motivation and Context

What if a user doesn't like the initial song we set as their favorite upon sign up? Well, now they can change it from any of the track modals. The only place left for this to be implemented is tapping on the song directly to change it while editing your profile.

### How Has This Been Tested?

I've gone through the app and manually tested the functionality in all the containers where this was implemented to ensure the feature is performing as expected.

### Types of Changes

- [x] Documentation
- ~~Bug fix~~
- [x] New feature
- ~~Breaking change~~

### Checklist

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly