### PR TITLE
Uninstall react native interactable

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -48,9 +48,6 @@ target 'brassroots' do
   # React Native Permissions
   pod 'ReactNativePermissions', :path=> '../node_modules/react-native-permissions'
 
-  # React Native Interactable
-  pod 'Interactable', :path => '../node_modules/react-native-interactable/lib/ios'
-
   # Background Timer
   pod 'react-native-background-timer', :path => '../node_modules/react-native-background-timer'
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -147,8 +147,6 @@ PODS:
     - nanopb (~> 0.3)
   - gRPC-Core/Interface (1.21.0)
   - GTMSessionFetcher/Core (1.2.2)
-  - Interactable (1.0.0):
-    - React
   - leveldb-library (1.22)
   - libwebp (1.0.3):
     - libwebp/demux (= 1.0.3)
@@ -419,7 +417,6 @@ DEPENDENCIES:
   - Firebase/Storage
   - Folly (from `../node_modules/react-native/third-party-podspecs/Folly.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
-  - Interactable (from `../node_modules/react-native-interactable/lib/ios`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
   - RCTTypeSafety (from `../node_modules/react-native/Libraries/TypeSafety`)
   - React (from `../node_modules/react-native`)
@@ -503,8 +500,6 @@ EXTERNAL SOURCES:
     :podspec: "../node_modules/react-native/third-party-podspecs/Folly.podspec"
   glog:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
-  Interactable:
-    :path: "../node_modules/react-native-interactable/lib/ios"
   RCTRequired:
     :path: "../node_modules/react-native/Libraries/RCTRequired"
   RCTTypeSafety:
@@ -602,7 +597,6 @@ SPEC CHECKSUMS:
   "gRPC-C++": 9dfe7b44821e7b3e44aacad2af29d2c21f7cde83
   gRPC-Core: c9aef9a261a1247e881b18059b84d597293c9947
   GTMSessionFetcher: 61bb0f61a4cb560030f1222021178008a5727a23
-  Interactable: b454a1fe6ded81774e066873c51396c65bd0fa49
   leveldb-library: 55d93ee664b4007aac644a782d11da33fba316f7
   libwebp: 057912d6d0abfb6357d8bb05c0ea470301f5d61e
   nanopb: 2901f78ea1b7b4015c860c2fdd1ea2fee1a18d48
@@ -646,6 +640,6 @@ SPEC CHECKSUMS:
   SDWebImageWebPCoder: 947093edd1349d820c40afbd9f42acb6cdecd987
   Yoga: 14927e37bd25376d216b150ab2a561773d57911f
 
-PODFILE CHECKSUM: 5760d8f4f6a2db52dffd48b61347d05630f63408
+PODFILE CHECKSUM: acbfb76f0e50a40d7025f86864f4586fc557a859
 
 COCOAPODS: 1.8.3

--- a/ios/brassroots.xcodeproj/xcshareddata/xcschemes/brassroots.xcscheme
+++ b/ios/brassroots.xcodeproj/xcshareddata/xcschemes/brassroots.xcscheme
@@ -78,7 +78,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"


### PR DESCRIPTION
### Description

The main purpose of this pull request is to remove the NPM package `react-native-interactable` from the project.

#### Test Plan

N/A

### Motivation and Context

The scroll headers have been totally revamped and updated using `react-native-reanimated` and `react-native-redash`. We've removed the need to have `react-native-interactable` included in the project entirely, so this PR aims to remove the package from the project.

### How Has This Been Tested?

I've gone through the app to ensure the functionality is working as expected. I also compiled the project after cleaning the project to ensure nothing else was using the package we aim to remove.

### Types of Changes

- [x] Documentation
- ~~Bug fix~~
- ~~New feature
- ~~Breaking change~~

### Checklist

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly