### PR TITLE
Refactor get session info

### DIFF
--- a/app/components/SessionHeader/index.js
+++ b/app/components/SessionHeader/index.js
@@ -46,12 +46,12 @@ type Props = {|
   name: string,
   saved: boolean,
   artists: string,
-  displayName: string,
+  displayName: ?string,
 |};
 
 type State = {||};
 
-export default class SessionHeader extends React.PureComponent<Props, State> {
+export default class SessionHeader extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
   }
@@ -119,7 +119,6 @@ export default class SessionHeader extends React.PureComponent<Props, State> {
         {trackID &&
           <SessionTrack
             trackID={trackID}
-            queueID={currentQueueID}
             name={name}
             saved={saved}
             artists={artists}

--- a/app/components/SessionTrack/index.js
+++ b/app/components/SessionTrack/index.js
@@ -8,6 +8,7 @@
 import * as React from 'react';
 import {View, Text, TouchableOpacity, Easing} from 'react-native';
 import TextTicker from 'react-native-text-ticker';
+import {Placeholder, PlaceholderLine, Fade} from 'rn-placeholder';
 import styles from './styles';
 
 // Icons
@@ -17,11 +18,10 @@ import SimpleLineIcons from 'react-native-vector-icons/SimpleLineIcons';
 
 type Props = {|
   trackID: string,
-  queueID: string,
   name: string,
   saved: boolean,
   artists: string,
-  displayName: string,
+  displayName: ?string,
   openModal: () => any,
 |};
 
@@ -33,9 +33,9 @@ export default class SessionTrack extends React.Component<Props, State> {
   }
 
   shouldComponentUpdate(nextProps: Props) {
-    const {trackID, queueID} = this.props;
-    const {trackID: newTrackID, queueID: newQueueID} = nextProps;
-    return trackID !== newTrackID || queueID !== newQueueID;
+    const {trackID, displayName} = this.props;
+    const {trackID: newTrackID, displayName: oldName} = nextProps;
+    return trackID !== newTrackID || displayName !== oldName;
   }
 
   render() {
@@ -66,9 +66,18 @@ export default class SessionTrack extends React.Component<Props, State> {
               {artists}
             </Text>
           </TextTicker>
-          <Text numberOfLines={1} style={styles.user}>
-            {displayName}
-          </Text>
+          {typeof displayName === 'string' &&
+            <Text numberOfLines={1} style={styles.user}>
+              {displayName}
+            </Text>
+          }
+          {typeof displayName !== 'string' &&
+            <View style={styles.loadWrap}>
+              <Placeholder Animate={Fade}>
+                <PlaceholderLine width={100} style={styles.loadingName} />
+              </Placeholder>
+            </View>
+          }
         </TouchableOpacity>
         {/* <TouchableOpacity style={styles.optionsButton} onPress={openModal} activeOpacity={0.5}>
           <SimpleLineIcons name='options' style={styles.options} />

--- a/app/components/SessionTrack/styles.js
+++ b/app/components/SessionTrack/styles.js
@@ -25,6 +25,8 @@ interface Styles {
   user: TextStyleProp,
   optionsButton: ViewStyleProp,
   options: TextStyleProp,
+  loadWrap: ViewStyleProp,
+  loadingName: ViewStyleProp,
 };
 
 const styles: Styles = StyleSheet.create({
@@ -106,6 +108,17 @@ const styles: Styles = StyleSheet.create({
     textAlign: 'right',
     fontSize: 30,
     color: '#fefefe',
+  },
+  loadWrap: {
+    paddingTop: 6,
+    width: 150,
+    height: 22,
+    justifyContent: 'center',
+  },
+  loadingName: {
+    marginTop: 10,
+    height: 16,
+    backgroundColor: '#888',
   },
 });
 

--- a/app/containers/LiveSessionView/index.js
+++ b/app/containers/LiveSessionView/index.js
@@ -510,13 +510,13 @@ class LiveSessionView extends React.Component {
       !currentSessionID
       || !currentTrackID
       || !sessions.allIDs.includes(currentSessionID)
-      || !queueTracks.allIDs.includes(currentQueueID)
     ) return <View></View>;
 
     const {totalListeners, distance, mode, ownerID} = sessions.byID[currentSessionID];
     const {album, durationMS, name, artists} = tracks.byID[currentTrackID];
-    const {userID} = queueTracks.byID[currentQueueID];
-    const {displayName} = users.byID[userID];
+    const queueTrack = queueTracks.allIDs.includes(currentQueueID)
+      ? queueTracks.byID[currentQueueID]
+      : null;
 
     let listenerTotal = 0;
     let formattedDistance = '';
@@ -579,7 +579,7 @@ class LiveSessionView extends React.Component {
         name={name}
         saved={userTracks.includes(currentTrackID)}
         artists={artists.map(a => a.name).join(', ')}
-        displayName={displayName}
+        displayName={queueTrack ? users.byID[queueTrack.userID].displayName : null}
       />
     );
   };

--- a/ios/brassroots.xcodeproj/xcshareddata/xcschemes/brassroots.xcscheme
+++ b/ios/brassroots.xcodeproj/xcshareddata/xcschemes/brassroots.xcscheme
@@ -78,7 +78,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"


### PR DESCRIPTION
### Description

The main purpose of this pull request is to enhance the process of opening the websocket for the session info.

#### Test Plan

N/A

### Motivation and Context

The general functionality of the app needs to be improved to be leaner and more performant overall. By refactoring not only the `GetSessionInfo` async thunk, but as well as the containers where the thunk is used, the process of getting the session info can be improved upon.

### How Has This Been Tested?

I've manually tested the performance of the app by going through the containers in question and seeing how the new implementation is performing.

### Types of Changes

- ~~Documentation~~
- ~~Bug fix~~
- [x] New feature
- ~~Breaking change~~

### Checklist

- [x] My code follows the code style of this project