### PR TITLE
Refactor get/paginate trending sessions

### DIFF
--- a/app/containers/ExploreTabView/index.js
+++ b/app/containers/ExploreTabView/index.js
@@ -12,7 +12,6 @@ import {
   VirtualizedList,
   ScrollView,
   RefreshControl,
-  InteractionManager,
 } from 'react-native';
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
@@ -55,6 +54,8 @@ class ExploreTabView extends React.Component {
     this.animatedOpacity = new Animated.Value(0);
     this.animatedIndex = new Animated.Value(-5);
     this.animatedFilterOpacity = new Animated.Value(0);
+
+    this._paginate = debounce(this.paginate, 50);
   }
 
   componentDidMount() {
@@ -66,7 +67,7 @@ class ExploreTabView extends React.Component {
     const timeDiff = moment().diff(lastUpdated, 'minutes', true);
 
     if (timeDiff >= 1 || trendingIDs.length === 0) {
-      InteractionManager.runAfterInteractions(getTrendingSessions);
+      setTimeout(getTrendingSessions, 100);
     }
   }
   
@@ -278,7 +279,7 @@ class ExploreTabView extends React.Component {
             getItemCount={data => data.length}
             removeClippedSubviews={false}
             showsVerticalScrollIndicator={false}
-            onEndReached={this.paginate}
+            onEndReached={this._paginate}
             onEndReachedThreshold={0.7}
             onRefresh={this.refresh}
             refreshing={refreshing}

--- a/ios/brassroots.xcodeproj/xcshareddata/xcschemes/brassroots.xcscheme
+++ b/ios/brassroots.xcodeproj/xcshareddata/xcschemes/brassroots.xcscheme
@@ -78,7 +78,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"


### PR DESCRIPTION
### Description

The main purpose of this pull request is to enhance the process of getting or paginate live sessions.

#### Test Plan

N/A

### Motivation and Context

The general functionality of the app needs to be improved to be leaner and more performant overall. By refactoring not only the `GetTrendingSessions` and `PaginateTrendingSessions` async thunks, but as well as the containers where the thunks are used, the process of getting or paginating live sessions can be improved upon.

### How Has This Been Tested?

I've manually tested the performance of the app by going through the containers in question and seeing how the new implementation is performing.

### Types of Changes

- ~~Documentation~~
- ~~Bug fix~~
- [x] New feature
- ~~Breaking change~~

### Checklist

- [x] My code follows the code style of this project