### PR TITLE
Refactor stop session info/queue listener

### DIFF
--- a/app/actions/queue/StopQueueListener/index.js
+++ b/app/actions/queue/StopQueueListener/index.js
@@ -37,7 +37,7 @@ export function stopQueueListener(
     dispatch(actions.request());
 
     try {
-      await unsubscribe();
+      unsubscribe();
       dispatch(actions.success());
     } catch (err) {
       dispatch(actions.failure(err));

--- a/app/actions/sessions/LeaveSession/index.js
+++ b/app/actions/sessions/LeaveSession/index.js
@@ -133,9 +133,6 @@ export function leaveSession(
 ): ThunkAction {
   return async (dispatch, _, {getFirestore}) => {
     dispatch(actions.request());
-    dispatch(stopSessionInfoListener(session.infoUnsubscribe));
-    // $FlowFixMe
-    dispatch(stopQueueListener(session.queueUnsubscribe));
 
     const firestore: FirestoreInstance = getFirestore();
     const geoRef: FirestoreRef = firestore.collection('geo');
@@ -198,6 +195,10 @@ export function leaveSession(
       batch.update(sessionRef.collection('users').doc(userID), {timeLeft, active: false, paused: true});
       batch.update(userRef, {currentSession: null, online: false});
       batch.update(userRef.collection('sessions').doc(session.id), {timeLeft});
+
+      dispatch(stopSessionInfoListener(session.infoUnsubscribe));
+      // $FlowFixMe
+      dispatch(stopQueueListener(session.queueUnsubscribe));
 
       await batch.commit();
     } catch (err) {


### PR DESCRIPTION
### Description

The main purpose of this pull request is to enhance the process of stopping the session info and queue listeners.

#### Test Plan

N/A

### Motivation and Context

The general functionality of the app needs to be improved to be leaner and more performant overall. By refactoring not only the `StopSessionInfoListener` and `StopQueueListener` async thunks, but as well as the containers where the thunks are used, the process of stopping the listeners can be improved upon.

### How Has This Been Tested?

I've manually tested the performance of the app by going through the containers in question and seeing how the new implementation is performing.

### Types of Changes

- ~~Documentation~~
- ~~Bug fix~~
- [x] New feature
- ~~Breaking change~~

### Checklist

- [x] My code follows the code style of this project