### PR TITLE
Refactor start player

### DIFF
--- a/app/actions/player/StartPlayer/index.js
+++ b/app/actions/player/StartPlayer/index.js
@@ -48,13 +48,9 @@ export function startPlayer(
     const sessionUserRef: FirestoreDoc = sessionRef.collection('users').doc(userID);
 
     try {
-      const promises = [
-        Spotify.playURI(`spotify:track:${trackID}`, 0, position),
-        sessionUserRef.update({paused: false}),
-      ];
-      
-      await Promise.all(promises);
+      await Spotify.playURI(`spotify:track:${trackID}`, 0, position);
       dispatch(actions.success());
+      await sessionUserRef.update({paused: false});
     } catch (err) {
       dispatch(actions.failure(err));
     }

--- a/ios/brassroots.xcodeproj/xcshareddata/xcschemes/brassroots.xcscheme
+++ b/ios/brassroots.xcodeproj/xcshareddata/xcschemes/brassroots.xcscheme
@@ -78,7 +78,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"


### PR DESCRIPTION
### Description

The main purpose of this pull request is to enhance the process of starting the player for the listener in a live session.

#### Test Plan

N/A

### Motivation and Context

The general functionality of the app needs to be improved to be leaner and more performant overall. By refactoring not only the `StartPlayer` async thunk, but as well as the containers where the thunk is used, the process of starting the player for the listener in a live session can be improved upon.

### How Has This Been Tested?

I've manually tested the performance of the app by going through the containers in question and seeing how the new implementation is performing.

### Types of Changes

- ~~Documentation~~
- ~~Bug fix~~
- [x] New feature
- ~~Breaking change~~

### Checklist

- [x] My code follows the code style of this project