### PR TITLE
Refactor get albums

### DIFF
--- a/app/containers/LibraryAlbumsView/index.js
+++ b/app/containers/LibraryAlbumsView/index.js
@@ -46,7 +46,7 @@ class LibraryAlbumsView extends React.Component {
     const timeDiff = moment().diff(last, 'minutes', true);
 
     if (!userAlbums.length || timeDiff >= 1) {
-      setTimeout(() => getAlbums(false, 0), 100);
+      setTimeout(() => getAlbums(true, 0), 100);
     }
   }
 

--- a/app/containers/LibraryAlbumsView/styles.js
+++ b/app/containers/LibraryAlbumsView/styles.js
@@ -21,7 +21,7 @@ interface Styles {
   title: TextStyleProp,
   rightIcon: ViewStyleProp,
   scrollContainer: ViewStyleProp,
-  scrollWrap: ViewStyleProp,
+  albumsWrap: ViewStyleProp,
   footer: ViewStyleProp,
   loadingGif: ImageStyleProp,
 };
@@ -84,10 +84,11 @@ const styles: Styles = StyleSheet.create({
     backgroundColor: '#1b1b1e',
     marginTop: 65,
   },
-  scrollWrap: {
+  albumsWrap: {
     flex: 1,
     zIndex: -1,
     backgroundColor: 'transparent',
+    marginTop: 65,
   },
   footer: {
     justifyContent: 'center',

--- a/app/containers/LibraryPlaylistsView/index.js
+++ b/app/containers/LibraryPlaylistsView/index.js
@@ -17,6 +17,8 @@ import {connect} from 'react-redux';
 import {Actions} from 'react-native-router-flux';
 import debounce from "lodash.debounce";
 import moment from 'moment';
+
+// Styles
 import styles from './styles';
 
 // Components

--- a/app/containers/LibraryTracksView/index.js
+++ b/app/containers/LibraryTracksView/index.js
@@ -17,6 +17,9 @@ import {connect} from "react-redux";
 import {Actions} from "react-native-router-flux";
 import Modal from "react-native-modal";
 import debounce from "lodash.debounce";
+import moment from 'moment';
+
+// Styles
 import styles from "./styles";
 
 // Components
@@ -68,14 +71,14 @@ class LibraryTracksView extends React.Component {
   }
 
   componentDidMount() {
-    const {getTracks, tracks: {userTracks}} = this.props;
+    const {getTracks, tracks: {userTracks, lastUpdated}} = this.props;
+    const last = moment(lastUpdated, 'ddd, MMM D, YYYY, h:mm:ss a');
+    const timeDiff = moment().diff(last, 'minutes', true);
 
     this.closeModal();
 
-    if (!userTracks.length) {
-      setTimeout(() => {
-        getTracks(true, 0);
-      }, 100);
+    if (!userTracks.length || timeDiff >= 1) {
+      setTimeout(() => getTracks(true, 0), 100);
     }
   }
 
@@ -364,34 +367,32 @@ class LibraryTracksView extends React.Component {
             removeClippedSubviews={false}
             onScroll={this.onScroll}
             scrollEventThrottle={16}
-            showsVerticalScrollIndicator={false}
             ListEmptyComponent={<Text>Nothing to show</Text>}
             refreshing={refreshing}
             onRefresh={this.handleRefresh}
             onEndReached={this._onEndReached}
             onEndReachedThreshold={0.5}
+            showsVerticalScrollIndicator={false}
           />
         }
         {(userTracks.length === 0 || !userTracks.length) &&
-          <View style={styles.scrollContainer}>
-            <View style={styles.scrollWrap}>
-              {(!fetching.includes('tracks') && trackError) && <Text>There was an error.</Text>}
-              {(fetching.includes('tracks') || (!fetching.includes('tracks') && !trackError)) &&
-                <View>
-                  <LoadingTrack />
-                  <LoadingTrack />
-                  <LoadingTrack />
-                  <LoadingTrack />
-                  <LoadingTrack />
-                  <LoadingTrack />
-                  <LoadingTrack />
-                  <LoadingTrack />
-                  <LoadingTrack />
-                  <LoadingTrack />
-                  <LoadingTrack />
-                </View>
-              }
-            </View>
+          <View style={styles.tracksWrap}>
+            {(!fetching.includes('tracks') && trackError) && <Text>There was an error.</Text>}
+            {(fetching.includes('tracks') || (!fetching.includes('tracks') && !trackError)) &&
+              <View>
+                <LoadingTrack />
+                <LoadingTrack />
+                <LoadingTrack />
+                <LoadingTrack />
+                <LoadingTrack />
+                <LoadingTrack />
+                <LoadingTrack />
+                <LoadingTrack />
+                <LoadingTrack />
+                <LoadingTrack />
+                <LoadingTrack />
+              </View>
+            }
           </View>
         }
         <Modal

--- a/app/containers/LibraryTracksView/styles.js
+++ b/app/containers/LibraryTracksView/styles.js
@@ -17,7 +17,7 @@ interface Styles {
   title: TextStyleProp,
   rightIcon: ViewStyleProp,
   scrollContainer: ViewStyleProp,
-  scrollWrap: ViewStyleProp,
+  tracksWrap: ViewStyleProp,
   shuffleButton: ViewStyleProp,
   shuffleButtonText: TextStyleProp,
   modal: ViewStyleProp,
@@ -85,10 +85,11 @@ const styles: Styles = StyleSheet.create({
     backgroundColor: '#1b1b1e',
     marginTop: 65,
   },
-  scrollWrap: {
+  tracksWrap: {
     flex: 1,
     zIndex: -1,
     backgroundColor: 'transparent',
+    marginTop: 65,
   },
   shuffleButton: {
     padding: 3,

--- a/app/reducers/albums.js
+++ b/app/reducers/albums.js
@@ -237,9 +237,7 @@ function update(
   const newUpdated: string = moment().format('ddd, MMM D, YYYY, h:mm:ss a');
   const updates: State = Array.isArray(fetching) && Array.isArray(userAlbums)
     ? {
-      lastUpdated: Array.isArray(action.albums)
-        ? newUpdated
-        : oldUpdated,
+      lastUpdated: Array.isArray(action.albums) ? newUpdated : oldUpdated,
       fetching: add && type ? fetching.concat(type) : type ? fetching.filter(t => t !== type) : fetching,
       refreshing: action.refreshing && !action.replace ? action.refreshing : false,
       error: haveError ? action.error : null,

--- a/app/reducers/albums.js
+++ b/app/reducers/albums.js
@@ -231,12 +231,15 @@ function update(
   action: Action,
   type?: string,
 ): State {
-  const {totalUserAlbums, fetching, userAlbums, refreshing} = state;
+  const {totalUserAlbums, fetching, userAlbums, refreshing, lastUpdated: oldUpdated} = state;
   const add: boolean = typeof action.type === 'string' && action.type.includes('REQUEST');
   const haveError: boolean = typeof action.type === 'string' && action.type.includes('FAILURE');
+  const newUpdated: string = moment().format('ddd, MMM D, YYYY, h:mm:ss a');
   const updates: State = Array.isArray(fetching) && Array.isArray(userAlbums)
     ? {
-      lastUpdated,
+      lastUpdated: Array.isArray(action.albums)
+        ? newUpdated
+        : oldUpdated,
       fetching: add && type ? fetching.concat(type) : type ? fetching.filter(t => t !== type) : fetching,
       refreshing: action.refreshing && !action.replace ? action.refreshing : false,
       error: haveError ? action.error : null,

--- a/app/reducers/conversations.js
+++ b/app/reducers/conversations.js
@@ -179,7 +179,7 @@ export function message(
 ): Message {
   switch (action.type) {
     case entitiesTypes.ADD_ENTITIES:
-      return updateObject(state, {...(action.item ? action.item : {})});
+      return updateObject(state, {...(typeof action.item === 'object' ? action.item : {})});
     default:
       return state;
   }

--- a/app/reducers/playlists.js
+++ b/app/reducers/playlists.js
@@ -325,7 +325,7 @@ function update(
         : oldUpdated,
       fetching: add && type ? oldFetch.concat(type) : type ? oldFetch.filter(t => t !== type) : oldFetch,
       error: haveError ? action.error : null,
-      totalUserPlaylists: action.total ? action.total : totalUserPlaylists,
+      totalUserPlaylists: typeof action.total === 'number' ? action.total : totalUserPlaylists,
       newPlaylist: action.updates && action.updates.newPlaylist && oldPlaylist
         ? updateObject(oldPlaylist, action.updates.newPlaylist)
         : {...oldPlaylist},

--- a/app/reducers/playlists.js
+++ b/app/reducers/playlists.js
@@ -320,9 +320,7 @@ function update(
   )
     ? {
       ...(action.updates ? action.updates : {}),
-      lastUpdated: Array.isArray(action.playlists)
-        ? newUpdated
-        : oldUpdated,
+      lastUpdated: Array.isArray(action.playlists) ? newUpdated : oldUpdated,
       fetching: add && type ? oldFetch.concat(type) : type ? oldFetch.filter(t => t !== type) : oldFetch,
       error: haveError ? action.error : null,
       totalUserPlaylists: typeof action.total === 'number' ? action.total : totalUserPlaylists,

--- a/app/reducers/tracks.js
+++ b/app/reducers/tracks.js
@@ -177,13 +177,14 @@ function update(
   action: Action,
   type?: string,
 ): State {
-  const {totalUserTracks, fetching, userTracks, refreshing} = state;
+  const {totalUserTracks, fetching, userTracks, refreshing, lastUpdated: oldUpdated} = state;
   const isAddRecent: boolean = typeof action.type === 'string' && action.type.includes('ADD_RECENT');
   const add: boolean = typeof action.type === 'string' && action.type.includes('REQUEST');
   const haveError: boolean = typeof action.type === 'string' && action.type.includes('FAILURE');
+  const newUpdated: string = moment().format("ddd, MMM D, YYYY, h:mm:ss a");
   const updates: State = Array.isArray(fetching) && Array.isArray(userTracks)
     ? {
-      lastUpdated,
+      lastUpdated: Array.isArray(action.tracks) ? newUpdated : oldUpdated,
       addingRecent: add && isAddRecent ? true : false,
       fetching: add && type ? fetching.concat(type) : type ? fetching.filter(t => t !== type) : fetching,
       refreshing: action.refreshing && !action.replace ? action.refreshing : false,

--- a/app/reducers/tracks.js
+++ b/app/reducers/tracks.js
@@ -188,7 +188,7 @@ function update(
       fetching: add && type ? fetching.concat(type) : type ? fetching.filter(t => t !== type) : fetching,
       refreshing: action.refreshing && !action.replace ? action.refreshing : false,
       error: haveError ? action.error : null,
-      totalUserTracks: action.total ? action.total : totalUserTracks,
+      totalUserTracks: typeof action.total === 'number' ? action.total : totalUserTracks,
       userTracks: (Array.isArray(action.tracks) && (refreshing || action.replace))
         ? [...action.tracks]
         : Array.isArray(action.tracks)


### PR DESCRIPTION
### Description

The main purpose of this pull request is to enhance the process of getting the current user's library albums from Spotify.

#### Test Plan

N/A

### Motivation and Context

The general functionality of the app needs to be improved to be leaner and more performant overall. By refactoring not only the `GetAlbums` async thunk, but as well as the containers where the thunk is used, the process of getting the user's library albums can be improved upon.

### How Has This Been Tested?

I've manually tested the performance of the app by going through the containers in question and seeing how the new implementation is performing.

### Types of Changes

- ~~Documentation~~
- ~~Bug fix~~
- [x] New feature
- ~~Breaking change~~

### Checklist

- [x] My code follows the code style of this project