### PR TITLE
Refactor change profile/cover photo

### DIFF
--- a/app/actions/users/ChangeCoverPhoto/index.js
+++ b/app/actions/users/ChangeCoverPhoto/index.js
@@ -61,11 +61,12 @@ export function changeCoverPhoto(
           ImageCropPicker.clean(),
         ];
 
-        await Promise.all(promises);
         dispatch(addEntities({users: {[userID]: {id: userID, coverImage}}}));
+        dispatch(actions.success());
+        await Promise.all(promises);
+      } else {
+        dispatch(actions.success());
       }
-
-      dispatch(actions.success());
     } catch (err) {
       dispatch(actions.failure(err));
     }

--- a/app/actions/users/ChangeProfilePhoto/index.js
+++ b/app/actions/users/ChangeProfilePhoto/index.js
@@ -61,11 +61,12 @@ export function changeProfilePhoto(
           ImageCropPicker.clean(),
         ];
 
-        await Promise.all(promises);
         dispatch(addEntities({users: {[userID]: {id: userID, profileImage}}}));
+        dispatch(actions.success());
+        await Promise.all(promises);
+      } else {
+        dispatch(actions.success());
       }
-
-      dispatch(actions.success());
     } catch (err) {
       dispatch(actions.failure(err));
     }


### PR DESCRIPTION
### Description

The main purpose of this pull request is to enhance the process of changing the current user's profile/cover photo.

#### Test Plan

N/A

### Motivation and Context

The general functionality of the app needs to be improved to be leaner and more performant overall. By refactoring not only the `ChangeProfilePhoto` and `ChangeCoverPhoto` async thunks, but as well as the containers where the thunks are used, the process of changing the current user's profile/cover photo can be improved upon.

### How Has This Been Tested?

I've manually tested the performance of the app by going through the containers in question and seeing how the new implementation is performing.

### Types of Changes

- ~~Documentation~~
- ~~Bug fix~~
- [x] New feature
- ~~Breaking change~~

### Checklist

- [x] My code follows the code style of this project