### PR TITLE
Archive app version 0.3.9

### DIFF
--- a/app/reducers/settings.js
+++ b/app/reducers/settings.js
@@ -149,7 +149,7 @@ export type {
  */
 export const initialState: State = {
   lastUpdated,
-  version: '0.3.8',
+  version: '0.3.9',
   initializing: false,
   loggingIn: false,
   loggedIn: false,

--- a/ios/brassroots.xcodeproj/project.pbxproj
+++ b/ios/brassroots.xcodeproj/project.pbxproj
@@ -746,7 +746,7 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = brassroots/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 0.3.8;
+				MARKETING_VERSION = 0.3.9;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -779,7 +779,7 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = brassroots/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 0.3.8;
+				MARKETING_VERSION = 0.3.9;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/ios/brassroots.xcodeproj/xcshareddata/xcschemes/brassroots.xcscheme
+++ b/ios/brassroots.xcodeproj/xcshareddata/xcschemes/brassroots.xcscheme
@@ -78,7 +78,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brassroots",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "The Brassroots mobile app",
   "private": false,
   "repository": {


### PR DESCRIPTION
### Description

The main purpose of this pull request is to archive the app at version 0.3.9.

#### Test Plan

N/A

### Motivation and Context

We fixed a couple bugs, one with the log out functionality, and another with the session chat input being hidden by the keyboard. We implemented some new functionality into the `GetUserSettings` async thunk to update the current user's app version on Firestore if the versions don't match.

### How Has This Been Tested?

I tested this manually by going through the app to make sure everything was working just as it was before the update.

### Types of Changes

- [x] Documentation
- ~~Bug fix~~
- [x] New feature
- ~~Breaking change~~

### Checklist

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly